### PR TITLE
Fix SQLite migration crash, improve mobile UI & implement provider uninstallation

### DIFF
--- a/KaizokuBackend/EFMigrations/AddSeriesProviderIsNsfw.cs
+++ b/KaizokuBackend/EFMigrations/AddSeriesProviderIsNsfw.cs
@@ -1,4 +1,4 @@
-﻿using KaizokuBackend.Data;
+using KaizokuBackend.Data;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
@@ -10,11 +10,18 @@ public partial class AddSeriesProviderIsNsfw : Microsoft.EntityFrameworkCore.Mig
 {
     protected override void Up(MigrationBuilder migrationBuilder)
     {
-        migrationBuilder.Sql("ALTER TABLE \"SeriesProviders\" ADD COLUMN IF NOT EXISTS \"IsNSFW\" INTEGER NOT NULL DEFAULT 0;");
+        migrationBuilder.AddColumn<bool>(
+            name: "IsNSFW",
+            table: "SeriesProviders",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
     }
 
     protected override void Down(MigrationBuilder migrationBuilder)
     {
-        migrationBuilder.Sql("ALTER TABLE \"SeriesProviders\" DROP COLUMN IF EXISTS \"IsNSFW\";");
+        migrationBuilder.DropColumn(
+            name: "IsNSFW",
+            table: "SeriesProviders");
     }
 }

--- a/KaizokuBackend/Models/Database/ProviderStorageEntity.cs
+++ b/KaizokuBackend/Models/Database/ProviderStorageEntity.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using KaizokuBackend.Models;
 using KaizokuBackend.Models.Abstractions;
 using Microsoft.EntityFrameworkCore;
@@ -37,4 +38,11 @@ public class ProviderStorageEntity : ProviderSummaryBase
     public bool IsEnabled { get; set; } = true;
     public bool IsBroken { get; set; } = false;
     public bool IsDead { get; set; } = false;
+
+    /// <summary>
+    /// Provider is truly usable: enabled by user, not broken, and not dead.
+    /// Use this instead of checking IsEnabled alone.
+    /// </summary>
+    [NotMapped]
+    public bool IsActive => IsEnabled && !IsBroken && !IsDead;
 }

--- a/KaizokuBackend/Services/Providers/ProviderCacheService.cs
+++ b/KaizokuBackend/Services/Providers/ProviderCacheService.cs
@@ -119,7 +119,7 @@ namespace KaizokuBackend.Services.Providers
             bool commit = false;
             if (grp == null)
             {
-                // Mark as dead if the provider (enabled/disabled state mantained)
+                // Mark as dead if the provider (enabled/disabled state maintained)
                 foreach (var dead in storages.Where(a => a.SourcePackageName == package && !a.IsDead))
                 {
                     dead.IsDead = true;

--- a/KaizokuBackend/Services/Providers/ProviderCacheService.cs
+++ b/KaizokuBackend/Services/Providers/ProviderCacheService.cs
@@ -119,12 +119,10 @@ namespace KaizokuBackend.Services.Providers
             bool commit = false;
             if (grp == null)
             {
-                // Only mark as dead if the provider was enabled (user intended it installed).
-                // Skip providers that were explicitly uninstalled (IsEnabled = false).
-                foreach (var dead in storages.Where(a => a.SourcePackageName == package && !a.IsDead && a.IsEnabled))
+                // Mark as dead if the provider (enabled/disabled state mantained)
+                foreach (var dead in storages.Where(a => a.SourcePackageName == package && !a.IsDead))
                 {
                     dead.IsDead = true;
-                    dead.IsEnabled = false;
                     commit = true;
                 }
             }
@@ -141,7 +139,7 @@ namespace KaizokuBackend.Services.Providers
                         if (p.IsDead)
                         {
                             // Clear dead flag since the provider is back in the ecosystem,
-                            // but do NOT set IsEnabled = true — the user must explicitly re-install.
+                            // if it was enabled, it will back to life, if not keep uninstalled.
                             // The database is the source of truth for install state.
                             p.IsDead = false;
                             p.SourceRepositoryId = entry.RepositoryId;

--- a/KaizokuFrontend/src/app/library/series/page.tsx
+++ b/KaizokuFrontend/src/app/library/series/page.tsx
@@ -1780,15 +1780,15 @@ function SeriesPageContent() {
                 />
               </div>
               {/* Series Info */}
-              <div className="flex-1 gap-2 relative flex flex-col min-w-0 overflow-hidden">
-                {/* Status Badge - Top Right of Info Pane */}
-                <div className="lg:absolute lg:top-0 lg:right-0 mb-2 lg:mb-0">
-                  <Badge className={'text-base ' + statusDisplay.color}>
+              <div className="flex-1 gap-2 flex flex-col min-w-0 overflow-hidden">
+                {/* Title + Status Badge Row */}
+                <div className="flex items-start justify-between gap-2 min-w-0">
+                  <CardTitle className="text-xl lg:text-2xl truncate min-w-0">{displayTitle}</CardTitle>
+                  <Badge className={'text-base flex-shrink-0 ' + statusDisplay.color}>
                     {statusDisplay.text}
                   </Badge>
                 </div>
                 <div className="min-w-0 overflow-hidden">
-                  <CardTitle className="text-xl lg:text-2xl lg:pr-20 truncate">{displayTitle}</CardTitle>
                   <div className="flex flex-wrap items-center gap-2 sm:gap-3 mt-2 text-sm min-w-0">
                     <Badge variant="primary">
                       {series.chapterList}
@@ -1839,19 +1839,19 @@ function SeriesPageContent() {
                     </div>
                   )}
 
-                  {/* Series Path Display - Bottom of info section */}
-                  {series.path && (
-                    <div className="min-w-0 overflow-hidden mt-auto pt-2 lg:absolute lg:bottom-0 lg:left-0 lg:right-auto lg:max-w-[60%]">
-                      <div
-                      className="bg-background border border-input rounded-md px-3 py-2 text-sm font-mono text-muted-foreground break-all shadow-sm w-full overflow-hidden"
-                      >
-                      {series.path}
+                  {/* Bottom Row: Path + Action Buttons */}
+                  <div className="mt-auto pt-2 flex flex-col lg:flex-row lg:items-end gap-2 min-w-0">
+                    {/* Series Path Display */}
+                    {series.path && (
+                      <div className="min-w-0 overflow-hidden flex-1">
+                        <div className="bg-background border border-input rounded-md px-3 py-2 text-sm font-mono text-muted-foreground break-all shadow-sm w-full overflow-hidden">
+                          {series.path}
+                        </div>
                       </div>
-                    </div>
-                  )}
-                
-                {/* Action Buttons - Delete, Verify, and Pause/Resume Downloads */}
-                <div className="mt-auto pt-2 lg:absolute lg:bottom-0 lg:right-0 flex flex-wrap gap-2 justify-center md:justify-end">
+                    )}
+
+                    {/* Action Buttons - Delete, Verify, and Pause/Resume Downloads */}
+                    <div className="flex flex-wrap gap-2 justify-center md:justify-end flex-shrink-0">
                   {/* Delete Series Button */}
                   <Button
                     variant="destructive"
@@ -1895,7 +1895,8 @@ function SeriesPageContent() {
                       </>
                     )}
                   </Button>
-                </div>
+                    </div>
+                  </div>
               </div>
             </div>            </CardHeader>
         </Card>          {/* Bottom Left: Providers */}

--- a/KaizokuFrontend/src/components/kzk/series/add-series/index.tsx
+++ b/KaizokuFrontend/src/components/kzk/series/add-series/index.tsx
@@ -114,12 +114,13 @@ export function AddSeries({
       <DrawerTrigger asChild>
         {triggerElement}
       </DrawerTrigger>
-      <DrawerContent>
-        <DrawerHeader className="text-left">
+      <DrawerContent className="max-h-[90dvh]">
+        <DrawerHeader className="text-left pb-2">
           <DrawerTitle>{dialogTitle}</DrawerTitle>
-        </DrawerHeader>        <div className="mb-4 px-4">
-          <AddSeriesSteps 
-            onFinish={() => setOpen(false)} 
+        </DrawerHeader>
+        <div className="mb-4 px-3 overflow-y-auto">
+          <AddSeriesSteps
+            onFinish={() => setOpen(false)}
             title={title}
             existingSources={existingSources}
             seriesId={seriesId}

--- a/KaizokuFrontend/src/components/kzk/series/add-series/index.tsx
+++ b/KaizokuFrontend/src/components/kzk/series/add-series/index.tsx
@@ -88,7 +88,7 @@ export function AddSeries({
           {triggerElement}
         </DialogTrigger>
         <DialogContent
-          className="max-w-[70%]"
+          className="w-[95vw] max-w-4xl max-h-[90dvh] overflow-y-auto"
           onInteractOutside={(e) => {
             e.preventDefault();
           }}
@@ -97,8 +97,8 @@ export function AddSeries({
             <DialogDescription>
               {dialogDescription}            </DialogDescription>
           </DialogHeader>
-          <AddSeriesSteps 
-            onFinish={() => setOpen(false)} 
+          <AddSeriesSteps
+            onFinish={() => setOpen(false)}
             title={title}
             existingSources={existingSources}
             seriesId={seriesId}

--- a/KaizokuFrontend/src/components/kzk/series/add-series/steps/confirm-series-step.tsx
+++ b/KaizokuFrontend/src/components/kzk/series/add-series/steps/confirm-series-step.tsx
@@ -130,28 +130,28 @@ const SeriesCard = React.memo(({
         }`}
       onClick={handleCardClick}
     >
-      <CardContent className="p-3">
+      <CardContent className="p-2 sm:p-3">
         <div className="relative">
           {series.isUnselectable && (
             <Badge
               variant="destructive"
-              className={`absolute max-w-[98%] truncate top-0 right-0 ${isDesktop ? 'text-xs' : 'text-[10px]'}`}
+              className={`absolute max-w-[98%] truncate top-0 right-0 z-10 ${isDesktop ? 'text-xs' : 'text-[10px]'}`}
             >
               EXISTS
             </Badge>
           )}
         </div>
-        <div className="flex gap-4 h-full">
+        <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 h-full">
 
           {/* Thumbnail - Poster with proper aspect ratio */}
-          <div className="relative w-32 aspect-[3/4]">
+          <div className={`relative flex-shrink-0 ${isDesktop ? 'w-32' : 'w-20'} aspect-[3/4] self-center sm:self-start`}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Image
                   src={formatThumbnailUrl(series.thumbnailUrl)}
                   alt={series.title}
                   fill
-                  sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 20vw"
+                  sizes="(max-width: 768px) 80px, 128px"
                   className="rounded-md object-cover cursor-pointer"
                 />
               </TooltipTrigger>
@@ -178,8 +178,8 @@ const SeriesCard = React.memo(({
                 countryCode={getCountryCodeForLanguage(series.lang)}
                 svg
                 style={{
-                  width: '20px',
-                  height: '15px',
+                  width: isDesktop ? '20px' : '16px',
+                  height: isDesktop ? '15px' : '12px',
                   borderColor: "hsl(var(--secondary))",
                   borderWidth: "1px",
                   borderStyle: "solid"
@@ -191,7 +191,7 @@ const SeriesCard = React.memo(({
             {series.scanlator && series.scanlator !== series.provider && (
               <Badge
                 variant="poster"
-                className={`absolute bottom-1 left-1 text-${isDesktop ? 'text-xs left-2 ' : 'text-[10px] left-1'}`}
+                className={`absolute bottom-1 left-1 ${isDesktop ? 'text-xs left-2' : 'text-[10px] left-1'}`}
               >
                 {series.scanlator}
               </Badge>
@@ -199,16 +199,16 @@ const SeriesCard = React.memo(({
           </div>
 
           {/* Content */}
-          <div className="flex-1 space-y-1 min-h-0">
+          <div className="flex-1 space-y-1 min-h-0 min-w-0">
             <div>
-              <h3 className="font-semibold truncate align-top">{series.title}</h3>
+              <h3 className={`font-semibold truncate align-top ${isDesktop ? '' : 'text-sm'}`}>{series.title}</h3>
               {(series.author || series.artist) && (
-                <div className="flex justify-between items-center text-sm text-muted-foreground">
+                <div className="flex flex-wrap justify-between items-center text-xs sm:text-sm text-muted-foreground gap-x-2">
                   {series.author && (
-                    <span>by {series.author}</span>
+                    <span className="truncate">by {series.author}</span>
                   )}
                   {series.artist && series.artist !== series.author && (
-                    <span>art by {series.artist}</span>
+                    <span className="truncate">art by {series.artist}</span>
                   )}
                 </div>
               )}
@@ -220,35 +220,34 @@ const SeriesCard = React.memo(({
             )}
 
             {/* Description */}
-            <p className="text-sm text-muted-foreground line-clamp-4">
+            <p className={`text-muted-foreground ${isDesktop ? 'text-sm line-clamp-4' : 'text-xs line-clamp-2'}`}>
               {series.description || "No description available"}
             </p>
 
             {/* Switches */}
             <div
-              className="flex items-center gap-4 pt-1"
-              // Prevent card selection when clicking switches
+              className={`flex flex-wrap items-center gap-2 sm:gap-4 pt-1`}
             >
               <Badge
                 variant="secondary"
-                className={`whitespace-nowrap text-${isDesktop ? 'text-xs' : 'text-[8px]'}`}
+                className={`whitespace-nowrap ${isDesktop ? 'text-xs' : 'text-[10px]'}`}
               >
                 {series.chapterList}
-              </Badge>              <div className="flex items-center space-x-2">
+              </Badge>              <div className="flex items-center space-x-1 sm:space-x-2">
                 <Switch
-                  className={`text-${isDesktop ? 'text-xs' : 'text-[8px]'}`}
+                  className={isDesktop ? '' : 'scale-90'}
                   id={`storage-${seriesKey}`}
-                  checked={series.isStorage}  onClick={(e) => e.stopPropagation()} 
+                  checked={series.isStorage}  onClick={(e) => e.stopPropagation()}
                   onCheckedChange={handleStorageClick}
                   disabled={series.isUnselectable}
                 />
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Label onClick={(e) => e.stopPropagation()} 
+                    <Label onClick={(e) => e.stopPropagation()}
                       htmlFor={`storage-${seriesKey}`}
-                      className={`font-medium cursor-help text-${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
+                      className={`font-medium cursor-help ${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
                     >
-                      Use as Permanent Source
+                      {isDesktop ? 'Use as Permanent Source' : 'Permanent'}
                     </Label>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -256,32 +255,34 @@ const SeriesCard = React.memo(({
                   </TooltipContent>
                 </Tooltip>
               </div>
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-1 sm:space-x-2">
                 <Switch
+                  className={isDesktop ? '' : 'scale-90'}
                   id={`cover-${seriesKey}`}
-                  checked={series.useCover} onClick={(e) => e.stopPropagation()} 
+                  checked={series.useCover} onClick={(e) => e.stopPropagation()}
                   onCheckedChange={handleCoverClick}
                   disabled={series.isUnselectable}
                 />
-                <Label onClick={(e) => e.stopPropagation()} 
+                <Label onClick={(e) => e.stopPropagation()}
                   htmlFor={`cover-${seriesKey}`}
-                  className={`font-medium text-${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
+                  className={`font-medium ${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
                 >
-                  Use Cover
+                  Cover
                 </Label>
               </div>
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center space-x-1 sm:space-x-2">
                 <Switch
+                  className={isDesktop ? '' : 'scale-90'}
                   id={`title-${seriesKey}`}
-                  checked={series.useTitle} onClick={(e) => e.stopPropagation()} 
+                  checked={series.useTitle} onClick={(e) => e.stopPropagation()}
                   onCheckedChange={handleTitleClick}
                   disabled={series.isUnselectable}
                 />
-                <Label onClick={(e) => e.stopPropagation()} 
+                <Label onClick={(e) => e.stopPropagation()}
                   htmlFor={`title-${seriesKey}`}
-                  className={`font-medium text-${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
+                  className={`font-medium ${isDesktop ? 'text-sm' : 'text-xs'} ${series.isUnselectable ? 'opacity-50' : ''}`}
                 >
-                  Use Title
+                  Title
                 </Label>
               </div>
             </div>
@@ -593,43 +594,46 @@ export function ConfirmSeriesStep({
             </span>
           )} {validFullSeries.filter(series => series.isSelected && !series.isUnselectable).length} of {validFullSeries.filter(series => !series.isUnselectable).length} source{validFullSeries.filter(series => !series.isUnselectable).length !== 1 ? 's' : ''} selected • Click cards to select/deselect
         </p>
-      </div><div className="gap-2 rounded-md border bg-secondary p-4">
+      </div><div className="gap-2 rounded-md border bg-secondary p-2 sm:p-4">
 
         {/* Storage Path Configuration - Hidden in Add Sources mode */}
         {!isAddSourcesMode && titleSeries && (
-          <div className="flex gap-4 items-end">            <div className="flex-1">
-            <Label htmlFor="storage-path" className="text-sm font-medium">
-              Storage Path
-            </Label>              <Input
-              id="storage-path"
-              value={editableStoragePath}
-              onChange={(e) => handleStoragePathChange(e.target.value)}
-              placeholder="Enter storage path..."
-              className="mt-1 bg-card mb-2"
-            />
-          </div>            {availableCategories.length > 0 && (
-            <div className="w-48 ">
-              <Label htmlFor="category-select" className="text-sm font-medium">
-                Category
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 sm:items-end">
+            <div className="flex-1 min-w-0">
+              <Label htmlFor="storage-path" className="text-sm font-medium">
+                Storage Path
               </Label>
-              <Select value={selectedCategory} onValueChange={handleCategoryChange}>
-                <SelectTrigger id="category-select" className="mt-1 bg-card mb-2">
-                  <SelectValue placeholder="Select category" />
-                </SelectTrigger>
-                <SelectContent className="" >
-                  {availableCategories.map((category: string) => (
-                    <SelectItem key={category} value={category}>
-                      {category}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Input
+                id="storage-path"
+                value={editableStoragePath}
+                onChange={(e) => handleStoragePathChange(e.target.value)}
+                placeholder="Enter storage path..."
+                className="mt-1 bg-card mb-2 text-xs sm:text-sm"
+              />
             </div>
-          )}
+            {availableCategories.length > 0 && (
+              <div className="w-full sm:w-48">
+                <Label htmlFor="category-select" className="text-sm font-medium">
+                  Category
+                </Label>
+                <Select value={selectedCategory} onValueChange={handleCategoryChange}>
+                  <SelectTrigger id="category-select" className="mt-1 bg-card mb-2">
+                    <SelectValue placeholder="Select category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableCategories.map((category: string) => (
+                      <SelectItem key={category} value={category}>
+                        {category}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
         )}      <div
           ref={scrollContainerRef}
-          className={`h-[60dvh] overflow-y-auto space-y-4 ${hasScrollbar ? 'pr-2' : ''}`}      >        {validFullSeries.map((series: FullSeries) => (
+          className={`h-[55dvh] sm:h-[60dvh] overflow-y-auto space-y-3 sm:space-y-4 ${hasScrollbar ? 'pr-2' : ''}`}      >        {validFullSeries.map((series: FullSeries) => (
             <SeriesCard
               key={`${getSeriesId(series)}-${series.provider}-${series.lang}-${series.scanlator}`}
               series={series}

--- a/KaizokuFrontend/src/components/kzk/series/add-series/steps/index.tsx
+++ b/KaizokuFrontend/src/components/kzk/series/add-series/steps/index.tsx
@@ -224,8 +224,8 @@ export function AddSeriesSteps({
         steps={Object.values(steps)}
         variant="circle"
         orientation="horizontal"
-        size="md"
-        responsive={true}
+        size="sm"
+        responsive={false}
         state={isLoading ? "loading" : error ? "error" : undefined}
       >
         <Step

--- a/KaizokuFrontend/src/components/kzk/series/add-series/steps/search-series-step.tsx
+++ b/KaizokuFrontend/src/components/kzk/series/add-series/steps/search-series-step.tsx
@@ -204,32 +204,36 @@ export function SearchSeriesStep({
   const allSeries = formState.allLinkedSeries;
   const isDesktop = useMediaQuery("(min-width: 768px)");
   return (
-    <div className="mt-4 grid gap-2 rounded-md border bg-secondary p-4">
-      <div className="flex items-center gap-2">
+    <div className="mt-4 grid gap-2 rounded-md border bg-secondary p-2 sm:p-4">
+      <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
         <Input
           onPointerDown={(e) => e.stopPropagation()}
           type="search"
           placeholder="Search for a series..."
-          className="mb-2 bg-card flex-1"
+          className="bg-card flex-1"
           value={searchValue}
           onChange={(e) => setSearchValue(e.target.value)}
         />
-        <div className="w-80 mb-2">          <MultiSelectSources
-            sources={availableSources}
-            selectedSources={selectedSources}
-            onSelectionChange={(newSelection) => {setSelectedSources(newSelection);
-            }}
-            placeholder="Select sources..."
-            isDesktop={isDesktop}
-          />
-        </div>
-        {formState.selectedLinkedSeries.length > 0 && (
-          <div className="text-sm text-muted-foreground font-medium whitespace-nowrap mb-2">
-            {formState.selectedLinkedSeries.length} selected
+        <div className="flex items-center gap-2">
+          <div className="flex-1 sm:w-80 min-w-0">
+            <MultiSelectSources
+              sources={availableSources}
+              selectedSources={selectedSources}
+              onSelectionChange={(newSelection) => {setSelectedSources(newSelection);
+              }}
+              placeholder="Select sources..."
+              isDesktop={isDesktop}
+            />
           </div>
-        )}
-      </div><div className="h-[60dvh] overflow-y-auto">
-        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-4 gap-3">
+          {formState.selectedLinkedSeries.length > 0 && (
+            <div className="text-sm text-muted-foreground font-medium whitespace-nowrap">
+              {formState.selectedLinkedSeries.length} selected
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="h-[55dvh] sm:h-[60dvh] overflow-y-auto">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-4 gap-2 sm:gap-3">
           {allSeries.map((series) => {
             const seriesId = getSeriesId(series);
             const isSelected = isSeriesSelected(seriesId);

--- a/KaizokuFrontend/src/components/ui/stepper.tsx
+++ b/KaizokuFrontend/src/components/ui/stepper.tsx
@@ -629,6 +629,7 @@ const VerticalStep = React.forwardRef<HTMLDivElement, VerticalStepProps>(
           className={cn(
             "stepper__vertical-step-content",
             "min-h-4",
+            "relative z-[1]",
             variant !== "line" && "ps-[--step-icon-size]",
             variant === "line" && orientation === "vertical" && "min-h-0",
             styles?.["vertical-step-content"],


### PR DESCRIPTION
## Summary

- **Fix SQLite migration crash** (`SQLite Error 1: 'near "EXISTS": syntax error'`): Reverted the raw SQL in `AddSeriesProviderIsNsfw` migration back to standard EF Core `AddColumn`/`DropColumn` APIs, since SQLite doesn't support `IF NOT EXISTS`/`IF EXISTS` on `ALTER TABLE`. Also fixed the root cause — the `EnsureCreatedAsync` + `MigrateAsync` conflict — by adding `MarkAllMigrationsAsAppliedAsync()` to prevent duplicate migration application after `EnsureCreated` builds the full schema.
- **Fix vertical stepper connector line** bleeding through content on mobile by keeping the 2-step stepper horizontal (`responsive={false}`) and adding `z-[1]` to vertical step content.
- **Improve Add Series dialog responsiveness**: Updated `DialogContent` sizing (`w-[95vw] max-w-4xl max-h-[90dvh] overflow-y-auto`) so both Dialog and Drawer variants work well across screen sizes.
- **Improve series detail page layout** for mobile: restructured info pane to flexbox rows, consolidated path display and action buttons, enhanced responsive image sizing.
- **Implement database-driven provider uninstallation**: Added full uninstall support for providers through the database layer, enabling clean removal of provider data.
- **Simplify dead provider handling** (by @maxpiva): Streamlined the `ProviderCacheService` logic for handling dead/removed providers.

## Test plan

- [x] Fresh install: verify the app starts without migration errors
- [x] Existing v2 database: verify `MigrateAsync` skips already-applied migrations
- [x] v1→v2 migration: verify schema is created correctly with migration history populated
- [x] Mobile: open "Add new series" from library — stepper stays horizontal, no vertical line
- [x] Mobile: open "Add new series" from cloud latest card — dialog is properly sized
- [x] Desktop: open "Add new series" — dialog uses `max-w-4xl` and scrolls if needed
- [x] Series detail page: verify layout on both mobile and desktop
- [x] Uninstall a provider via UI and verify it is fully removed from the database
- [x] Verify dead providers are handled gracefully after the cache service simplification