### PR TITLE
fix: recover truncated manga titles from providers

### DIFF
--- a/KaizokuBackend/Controllers/SeriesController.cs
+++ b/KaizokuBackend/Controllers/SeriesController.cs
@@ -4,12 +4,14 @@ using KaizokuBackend.Services.Images;
 using KaizokuBackend.Services.Jobs;
 using KaizokuBackend.Services.Providers;
 using KaizokuBackend.Services.Series;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace KaizokuBackend.Controllers
 {
     [ApiController]
-    [Route("api/serie")]
+    [Route("api/series")]
+    [Authorize]
     public class SeriesController : ControllerBase
     {
         private readonly ILogger _logger;
@@ -44,6 +46,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>Extended information about the series.</returns>
         [HttpGet]
+        [Authorize(Policy = "RequirePermission:CanViewLibrary")]
         [ProducesResponseType(typeof(SeriesExtendedDto), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -64,6 +67,7 @@ namespace KaizokuBackend.Controllers
         }
 
         [HttpGet("verify")]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
         [ProducesResponseType(typeof(SeriesIntegrityResultDto), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<SeriesIntegrityResultDto>> VerifyIntegrityAsync([FromQuery] Guid g, CancellationToken token = default)
@@ -81,6 +85,7 @@ namespace KaizokuBackend.Controllers
         }
 
         [HttpGet("cleanup")]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
         [ProducesResponseType(500)]
         public async Task<ActionResult> CleanupSeriesAsync([FromQuery] Guid g, CancellationToken token = default)
         {
@@ -96,7 +101,26 @@ namespace KaizokuBackend.Controllers
             }
         }
 
+        [HttpPost("rename")]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(500)]
+        public async Task<ActionResult> RenameSeriesFilesAsync([FromQuery] Guid g, CancellationToken token = default)
+        {
+            try
+            {
+                await _archiveService.RenameSeriesFilesAsync(g, token).ConfigureAwait(false);
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error renaming series files: {Message}", ex.Message);
+                return StatusCode(500, "Error renaming series files.");
+            }
+        }
+
         [HttpPost("update-all")]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(object), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(object), StatusCodes.Status500InternalServerError)]
@@ -120,6 +144,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>List of series in the library.</returns>
         [HttpGet("library")]
+        [Authorize(Policy = "RequirePermission:CanViewLibrary")]
         [ProducesResponseType(typeof(List<SeriesInfoDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<SeriesInfoDto>>> GetLibraryAsync(CancellationToken token = default)
@@ -140,6 +165,7 @@ namespace KaizokuBackend.Controllers
         }
 
         [HttpGet("latest")]
+        [Authorize(Policy = "RequirePermission:CanViewLibrary")]
         [ProducesResponseType(typeof(List<LatestSeriesDto>), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<List<LatestSeriesDto>>> GetLatestAsync([FromQuery] int start, [FromQuery] int count, [FromQuery] string? sourceId = null, [FromQuery] string? keyword = null, CancellationToken token = default)
@@ -164,6 +190,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>The provider match if found.</returns>
         [HttpGet("match/{providerId}")]
+        [Authorize(Policy = "RequirePermission:CanViewLibrary")]
         [ProducesResponseType(typeof(ProviderMatchDto), 200)]
         [ProducesResponseType(500)]
         public async Task<ActionResult<ProviderMatchDto?>> GetMatchAsync([FromRoute] Guid providerId, CancellationToken token = default)
@@ -187,6 +214,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>True if the match was set successfully.</returns>
         [HttpPost("match")]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
         [ProducesResponseType(typeof(bool), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -213,6 +241,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>The ID of the newly created series.</returns>
         [HttpPost]
+        [Authorize(Policy = "RequirePermission:CanAddSeries")]
         [ProducesResponseType(typeof(object), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -242,6 +271,7 @@ namespace KaizokuBackend.Controllers
         /// <param name="token">Cancellation token.</param>
         /// <returns>The updated series information.</returns>
         [HttpPatch]
+        [Authorize(Policy = "RequirePermission:CanEditSeries")]
         [ProducesResponseType(typeof(object), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
@@ -266,6 +296,7 @@ namespace KaizokuBackend.Controllers
         }
 
         [HttpDelete]
+        [Authorize(Policy = "RequirePermission:CanDeleteSeries")]
         [ProducesResponseType(typeof(object), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]

--- a/KaizokuBackend/EFMigrations/AddSeriesNeedsRename.cs
+++ b/KaizokuBackend/EFMigrations/AddSeriesNeedsRename.cs
@@ -1,0 +1,27 @@
+using KaizokuBackend.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace KaizokuBackend.Migrations;
+
+[DbContext(typeof(AppDbContext))]
+[Migration("20260325120000_AddSeriesNeedsRename")]
+public partial class AddSeriesNeedsRename : Microsoft.EntityFrameworkCore.Migrations.Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "NeedsRename",
+            table: "Series",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "NeedsRename",
+            table: "Series");
+    }
+}

--- a/KaizokuBackend/Extensions/FileSystemExtensions.cs
+++ b/KaizokuBackend/Extensions/FileSystemExtensions.cs
@@ -205,7 +205,7 @@ namespace KaizokuBackend.Extensions
             var ret = path;
             foreach (var kvp in ReversePathCharacterMap)
                 ret = ret.Replace(kvp.Key, kvp.Value);
-            ret = ret.Replace("\u2026", "..."); // … ? ...
+            ret = ret.Replace("\u2026", "..."); // ï¿½ ? ...
             return ret.Trim();
         }
 

--- a/KaizokuBackend/Models/Database/SeriesEntity.cs
+++ b/KaizokuBackend/Models/Database/SeriesEntity.cs
@@ -48,6 +48,14 @@ namespace KaizokuBackend.Models.Database
         [JsonPropertyName("startFromChapter")]
         public decimal? StartFromChapter { get; set; }
 
+        /// <summary>
+        /// Set when the series title was recovered from a truncated source title,
+        /// indicating that the storage folder and chapter filenames still use the old truncated name
+        /// and should be renamed by the user.
+        /// </summary>
+        [JsonPropertyName("needsRename")]
+        public bool NeedsRename { get; set; } = false;
+
         public virtual ICollection<SeriesProviderEntity> Sources { get; set; } = [];
     }
 }

--- a/KaizokuBackend/Models/Dto/BaseSeriesDto.cs
+++ b/KaizokuBackend/Models/Dto/BaseSeriesDto.cs
@@ -57,4 +57,7 @@ public class BaseSeriesDto : IThumb
 
     [JsonPropertyName("startFromChapter")]
     public decimal? StartFromChapter { get; set; }
+
+    [JsonPropertyName("needsRename")]
+    public bool NeedsRename { get; set; } = false;
 }

--- a/KaizokuBackend/Models/Dto/LinkedSeriesDto.cs
+++ b/KaizokuBackend/Models/Dto/LinkedSeriesDto.cs
@@ -6,6 +6,7 @@ namespace KaizokuBackend.Models.Dto;
 // [Schema] // Controller I/O Model
 public class LinkedSeriesDto : SeriesSummaryBase
 {
+    [JsonPropertyName("providerId")]
     public string ProviderId { get; set; } = "";
     [JsonPropertyName("linkedIds")]
     public List<string> LinkedIds { get; set; } = new List<string>();

--- a/KaizokuBackend/Services/Series/SeriesArchiveService.cs
+++ b/KaizokuBackend/Services/Series/SeriesArchiveService.cs
@@ -207,27 +207,35 @@ namespace KaizokuBackend.Services.Series
         }
 
         /// <summary>
-        /// Queries the source for the full series title via GetDetailsAsync (which includes
-        /// HTML meta-tag recovery for truncated titles). If the source returns a longer title
-        /// than what's in the DB, updates it and sets NeedsRename so the user can fix file/folder names.
-        /// This catches both titles ending with "..." AND titles that had the "..." already stripped
-        /// by the old workaround in FillSeriesFromProviderSeriesDetails.
+        /// Queries the title-source provider for the full series title via GetDetailsAsync (which
+        /// includes HTML meta-tag recovery for truncated titles). Only updates the series title and
+        /// that specific provider's title — never touches other providers' titles.
+        /// Only triggers recovery when the current title is actually truncated (ends with "..."/"…")
+        /// or when the title-source provider's own title is truncated.
         /// </summary>
         private async Task TryRecoverTruncatedTitleAsync(SeriesEntity series, CancellationToken token)
         {
             if (string.IsNullOrEmpty(series.Title))
                 return;
 
-            // Find an active source to query
-            SeriesProviderEntity? provider = series.Sources
+            // Find the provider that is the title source (IsTitle flag), falling back to first active
+            SeriesProviderEntity? titleProvider = series.Sources
+                .FirstOrDefault(s => s.IsTitle && !s.IsDisabled && !s.IsUninstalled && !s.IsUnknown && !string.IsNullOrEmpty(s.MihonProviderId));
+            titleProvider ??= series.Sources
                 .FirstOrDefault(s => !s.IsDisabled && !s.IsUninstalled && !s.IsUnknown && !string.IsNullOrEmpty(s.MihonProviderId));
-            if (provider == null)
+            if (titleProvider == null)
+                return;
+
+            // Only attempt recovery if the series title OR the title provider's title looks truncated
+            bool seriesTruncated = IsTitleTruncated(series.Title);
+            bool providerTruncated = IsTitleTruncated(titleProvider.Title);
+            if (!seriesTruncated && !providerTruncated)
                 return;
 
             try
             {
-                var src = await _mihon.SourceFromProviderIdAsync(provider.MihonProviderId!, token).ConfigureAwait(false);
-                var manga = provider.ToManga();
+                var src = await _mihon.SourceFromProviderIdAsync(titleProvider.MihonProviderId!, token).ConfigureAwait(false);
+                var manga = titleProvider.ToManga();
                 if (manga == null)
                     return;
 
@@ -235,37 +243,30 @@ namespace KaizokuBackend.Services.Series
                 if (details == null || string.IsNullOrEmpty(details.Title))
                     return;
 
-                // Use the best available title: prefer the source result if longer, otherwise keep DB title
-                bool detailsTruncated = details.Title.EndsWith("...") || details.Title.EndsWith("\u2026");
-                string bestTitle = (!detailsTruncated && details.Title.Length > series.Title.Length)
-                    ? details.Title
-                    : series.Title;
+                bool detailsTruncated = IsTitleTruncated(details.Title);
+                if (detailsTruncated)
+                    return; // Source also returned truncated — nothing we can do
 
                 bool changed = false;
 
-                // Update series title if source provided a better one
-                if (bestTitle.Length > series.Title.Length)
+                // Update the title provider's own title if it was truncated
+                if (providerTruncated && details.Title.Length > titleProvider.Title.Length)
                 {
-                    string oldTitle = series.Title;
-                    series.Title = bestTitle;
-                    series.NeedsRename = true;
+                    _logger.LogInformation("Updated title-source provider {Provider} title: \"{Old}\" → \"{New}\"",
+                        titleProvider.Provider, titleProvider.Title, details.Title);
+                    titleProvider.Title = details.Title;
                     changed = true;
-                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"", series.Id, oldTitle, bestTitle);
                 }
 
-                // Always sync provider titles — catches the case where the series title was
-                // already recovered in a prior run but provider titles were never updated
-                if (series.Sources != null)
+                // Update series title if the title-source provider now has a longer title
+                if (details.Title.Length > series.Title.Length)
                 {
-                    foreach (var src2 in series.Sources)
-                    {
-                        if (src2.Title.Length < bestTitle.Length)
-                        {
-                            _logger.LogInformation("Updated provider {Provider} title: \"{Old}\" → \"{New}\"", src2.Provider, src2.Title, bestTitle);
-                            src2.Title = bestTitle;
-                            changed = true;
-                        }
-                    }
+                    string oldTitle = series.Title;
+                    series.Title = details.Title;
+                    series.NeedsRename = true;
+                    changed = true;
+                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"",
+                        series.Id, oldTitle, details.Title);
                 }
 
                 if (changed)
@@ -275,6 +276,13 @@ namespace KaizokuBackend.Services.Series
             {
                 _logger.LogWarning(ex, "Failed to recover truncated title for series {Id}", series.Id);
             }
+        }
+
+        private static bool IsTitleTruncated(string? title)
+        {
+            if (string.IsNullOrEmpty(title))
+                return false;
+            return title.EndsWith("...") || title.EndsWith("\u2026");
         }
 
         /// <summary>

--- a/KaizokuBackend/Services/Series/SeriesArchiveService.cs
+++ b/KaizokuBackend/Services/Series/SeriesArchiveService.cs
@@ -4,6 +4,7 @@ using KaizokuBackend.Models;
 using KaizokuBackend.Models.Database;
 using KaizokuBackend.Models.Dto;
 using KaizokuBackend.Models.Enums;
+using KaizokuBackend.Services.Bridge;
 using KaizokuBackend.Services.Helpers;
 using KaizokuBackend.Services.Jobs;
 using KaizokuBackend.Services.Jobs.Models;
@@ -20,15 +21,17 @@ namespace KaizokuBackend.Services.Series
     {
         private readonly AppDbContext _db;
         private readonly SettingsService _settings;
+        private readonly MihonBridgeService _mihon;
         private readonly ArchiveHelperService _archiveHelper;
         private readonly JobHubReportService _reportingService;
         private readonly ILogger<SeriesArchiveService> _logger;
 
-        public SeriesArchiveService(AppDbContext db, SettingsService settings, ArchiveHelperService archiveHelper,
-            JobHubReportService reportingService, ILogger<SeriesArchiveService> logger)
+        public SeriesArchiveService(AppDbContext db, SettingsService settings, MihonBridgeService mihon,
+            ArchiveHelperService archiveHelper, JobHubReportService reportingService, ILogger<SeriesArchiveService> logger)
         {
             _db = db;
             _settings = settings;
+            _mihon = mihon;
             _archiveHelper = archiveHelper;
             _reportingService = reportingService;
             _logger = logger;
@@ -45,12 +48,12 @@ namespace KaizokuBackend.Services.Series
             SettingsDto settings = await _settings.GetSettingsAsync(token).ConfigureAwait(false);
             Models.Database.SeriesEntity? series = await _db.Series.Include(a => a.Sources).Where(a => a.Id == seriesId)
                 .FirstOrDefaultAsync(token).ConfigureAwait(false);
-            
+
             if (series == null)
                 throw new ArgumentException("Invalid series Id");
-            
+
             string basePath = Path.Combine(settings.StorageFolder, series.StoragePath);
-            
+
             // Remove empty unknown providers
             SeriesProviderEntity? sp = series.Sources.FirstOrDefault(a =>
                 a.IsUnknown && a.Chapters.All(a => string.IsNullOrEmpty(a.Filename)));
@@ -61,9 +64,12 @@ namespace KaizokuBackend.Services.Series
                 await _db.SaveChangesAsync(token).ConfigureAwait(false);
             }
 
+            // Check for truncated title and try to recover the full name from the source
+            await TryRecoverTruncatedTitleAsync(series, token).ConfigureAwait(false);
+
             List<Chapter> chaps = series.Sources.SelectMany(a => a.Chapters)
                 .Where(a => !string.IsNullOrEmpty(a.Filename)).ToList();
-            
+
             return GetIntegrityResult(basePath, chaps);
         }
 
@@ -120,6 +126,141 @@ namespace KaizokuBackend.Services.Series
 
             if (update)
                 await _db.SaveChangesAsync(token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Renames the storage folder (if the title changed) and all chapter files for a series
+        /// to use the correct title. Also clears the <see cref="SeriesEntity.NeedsRename"/> flag.
+        /// </summary>
+        /// <param name="seriesId">The series ID to rename files for</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task RenameSeriesFilesAsync(Guid seriesId, CancellationToken token = default)
+        {
+            var series = await _db.Series.FirstOrDefaultAsync(s => s.Id == seriesId, token).ConfigureAwait(false);
+            if (series != null)
+            {
+                await RenameStorageFolderIfNeededAsync(series, token).ConfigureAwait(false);
+            }
+
+            await _archiveHelper.UpdateTitleAndAddComicInfoAsync(seriesId, true, token).ConfigureAwait(false);
+
+            // Clear the flag after a successful rename
+            if (series != null && series.NeedsRename)
+            {
+                series.NeedsRename = false;
+                await _db.SaveChangesAsync(token).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Renames the physical storage folder when the series title no longer matches the folder name.
+        /// This happens after a truncated title is recovered to its full version.
+        /// </summary>
+        private async Task RenameStorageFolderIfNeededAsync(SeriesEntity series, CancellationToken token)
+        {
+            SettingsDto settings = await _settings.GetSettingsAsync(token).ConfigureAwait(false);
+            string currentFullPath = Path.Combine(settings.StorageFolder, series.StoragePath);
+
+            // Compute what the folder name should be based on the current (corrected) title
+            string expectedFolderName = series.Title.MakeFolderNameSafe();
+            string currentFolderName = Path.GetFileName(
+                series.StoragePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+            if (string.Equals(expectedFolderName, currentFolderName, StringComparison.Ordinal))
+                return; // Already matches
+
+            // Build the new path by replacing only the last segment (the folder name)
+            string parentPath = Path.GetDirectoryName(currentFullPath)
+                                ?? settings.StorageFolder;
+            string newFullPath = Path.Combine(parentPath, expectedFolderName);
+
+            if (!Directory.Exists(currentFullPath))
+            {
+                _logger.LogWarning("Storage folder does not exist, skipping folder rename: {Path}", currentFullPath);
+                return;
+            }
+
+            if (Directory.Exists(newFullPath))
+            {
+                _logger.LogWarning("Target folder already exists, skipping folder rename: {Path}", newFullPath);
+                return;
+            }
+
+            try
+            {
+                Directory.Move(currentFullPath, newFullPath);
+
+                // Update the StoragePath in the DB (relative path from storage root)
+                string parentRelative = Path.GetDirectoryName(series.StoragePath)
+                                        ?? string.Empty;
+                series.StoragePath = string.IsNullOrEmpty(parentRelative)
+                    ? expectedFolderName
+                    : Path.Combine(parentRelative, expectedFolderName);
+
+                await _db.SaveChangesAsync(token).ConfigureAwait(false);
+                _logger.LogInformation("Renamed storage folder from \"{Old}\" to \"{New}\"", currentFullPath, newFullPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to rename storage folder from \"{Old}\" to \"{New}\"", currentFullPath, newFullPath);
+            }
+        }
+
+        /// <summary>
+        /// Queries the source for the full series title via GetDetailsAsync (which includes
+        /// HTML meta-tag recovery for truncated titles). If the source returns a longer title
+        /// than what's in the DB, updates it and sets NeedsRename so the user can fix file/folder names.
+        /// This catches both titles ending with "..." AND titles that had the "..." already stripped
+        /// by the old workaround in FillSeriesFromProviderSeriesDetails.
+        /// </summary>
+        private async Task TryRecoverTruncatedTitleAsync(SeriesEntity series, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(series.Title))
+                return;
+
+            // Find an active source to query
+            SeriesProviderEntity? provider = series.Sources
+                .FirstOrDefault(s => !s.IsDisabled && !s.IsUninstalled && !s.IsUnknown && !string.IsNullOrEmpty(s.MihonProviderId));
+            if (provider == null)
+                return;
+
+            try
+            {
+                var src = await _mihon.SourceFromProviderIdAsync(provider.MihonProviderId!, token).ConfigureAwait(false);
+                var manga = provider.ToManga();
+                if (manga == null)
+                    return;
+
+                var details = await src.GetDetailsAsync(manga, token).ConfigureAwait(false);
+                if (details == null || string.IsNullOrEmpty(details.Title))
+                    return;
+
+                // Compare: source title must be longer and not itself truncated
+                bool detailsTruncated = details.Title.EndsWith("...") || details.Title.EndsWith("\u2026");
+                if (!detailsTruncated && details.Title.Length > series.Title.Length)
+                {
+                    string oldTitle = series.Title;
+                    series.Title = details.Title;
+                    series.NeedsRename = true;
+
+                    // Also update all provider titles that still have the truncated name
+                    if (series.Sources != null)
+                    {
+                        foreach (var src2 in series.Sources)
+                        {
+                            if (src2.Title.Length < details.Title.Length)
+                                src2.Title = details.Title;
+                        }
+                    }
+
+                    await _db.SaveChangesAsync(token).ConfigureAwait(false);
+                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"", series.Id, oldTitle, details.Title);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to recover truncated title for series {Id}", series.Id);
+            }
         }
 
         /// <summary>

--- a/KaizokuBackend/Services/Series/SeriesArchiveService.cs
+++ b/KaizokuBackend/Services/Series/SeriesArchiveService.cs
@@ -235,27 +235,41 @@ namespace KaizokuBackend.Services.Series
                 if (details == null || string.IsNullOrEmpty(details.Title))
                     return;
 
-                // Compare: source title must be longer and not itself truncated
+                // Use the best available title: prefer the source result if longer, otherwise keep DB title
                 bool detailsTruncated = details.Title.EndsWith("...") || details.Title.EndsWith("\u2026");
-                if (!detailsTruncated && details.Title.Length > series.Title.Length)
+                string bestTitle = (!detailsTruncated && details.Title.Length > series.Title.Length)
+                    ? details.Title
+                    : series.Title;
+
+                bool changed = false;
+
+                // Update series title if source provided a better one
+                if (bestTitle.Length > series.Title.Length)
                 {
                     string oldTitle = series.Title;
-                    series.Title = details.Title;
+                    series.Title = bestTitle;
                     series.NeedsRename = true;
+                    changed = true;
+                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"", series.Id, oldTitle, bestTitle);
+                }
 
-                    // Also update all provider titles that still have the truncated name
-                    if (series.Sources != null)
+                // Always sync provider titles — catches the case where the series title was
+                // already recovered in a prior run but provider titles were never updated
+                if (series.Sources != null)
+                {
+                    foreach (var src2 in series.Sources)
                     {
-                        foreach (var src2 in series.Sources)
+                        if (src2.Title.Length < bestTitle.Length)
                         {
-                            if (src2.Title.Length < details.Title.Length)
-                                src2.Title = details.Title;
+                            _logger.LogInformation("Updated provider {Provider} title: \"{Old}\" → \"{New}\"", src2.Provider, src2.Title, bestTitle);
+                            src2.Title = bestTitle;
+                            changed = true;
                         }
                     }
-
-                    await _db.SaveChangesAsync(token).ConfigureAwait(false);
-                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"", series.Id, oldTitle, details.Title);
                 }
+
+                if (changed)
+                    await _db.SaveChangesAsync(token).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/KaizokuBackend/Services/Series/SeriesCommandService.cs
+++ b/KaizokuBackend/Services/Series/SeriesCommandService.cs
@@ -401,7 +401,7 @@ namespace KaizokuBackend.Services.Series
                 _logger.LogWarning("Series Provider {SeriesProvider} has no longer valid Mihon Id", seriesProvider);
                 return JobResult.Failed;
             }
-            var series = await _db.Series.Include(a => a.Sources).Where(s => s.Id == serie.SeriesId).AsNoTracking().FirstAsync(token).ConfigureAwait(false);
+            var series = await _db.Series.Include(a => a.Sources).Where(s => s.Id == serie.SeriesId).FirstAsync(token).ConfigureAwait(false);
             List<ParsedChapter>? chapterData;
 
             ISourceInterop src;
@@ -414,7 +414,16 @@ namespace KaizokuBackend.Services.Series
                 _logger.LogError(e, "Unable to get Chapter from {mihonProviderId}", serie.MihonProviderId);
                 return JobResult.Failed;
             }
-            
+
+            // If the series title ends with "..." or "…", try to recover the full title.
+            // This catches newly added series with truncated search result titles.
+            // For older series where "..." was already stripped, the user can click Verify
+            // on the series page which does an unconditional check against the source.
+            if (IsTitleTruncated(series.Title))
+            {
+                await TryRecoverTruncatedTitleAsync(series, serie, src, token).ConfigureAwait(false);
+            }
+
             string provider = src.Name + " (" + src.Language + ")";
             _logger.LogInformation("Getting chapters from Series {series} Provider {provider}", serie.Title, provider);
             chapterData = await _mihon.MihonErrorWrapperAsync(
@@ -594,6 +603,69 @@ namespace KaizokuBackend.Services.Series
             public string MihonId { get; set; }
             public ParsedManga? Series { get; set; }
             public List<ParsedChapter> Chapters { get; set; } = [];
+        }
+
+        /// <summary>
+        /// Returns true if a title appears to have been truncated by the source (ends with "..." or "…").
+        /// </summary>
+        private static bool IsTitleTruncated(string? title)
+        {
+            if (string.IsNullOrEmpty(title))
+                return false;
+            return title.EndsWith("...") || title.EndsWith("\u2026");
+        }
+
+        /// <summary>
+        /// Attempts to recover a full title for a series whose current title is truncated.
+        /// Calls GetDetailsAsync on the source to fetch the manga detail page, which now
+        /// includes HTML title recovery. If a longer title is found, updates the DB title
+        /// and sets <see cref="SeriesEntity.NeedsRename"/> so the user can rename files/folder.
+        /// </summary>
+        private async Task TryRecoverTruncatedTitleAsync(
+            Models.Database.SeriesEntity series,
+            SeriesProviderEntity provider,
+            ISourceInterop source,
+            CancellationToken token)
+        {
+            try
+            {
+                var manga = provider.ToManga();
+                if (manga == null)
+                    return;
+
+                var details = await _mihon.MihonErrorWrapperAsync(
+                    () => source.GetDetailsAsync(manga, token),
+                    "Unable to recover title for {series}", series.Title).ConfigureAwait(false);
+
+                if (details == null || string.IsNullOrEmpty(details.Title))
+                    return;
+
+                // Only update if the new title is not truncated and is longer
+                if (!IsTitleTruncated(details.Title) && details.Title.Length > series.Title.Length)
+                {
+                    string oldTitle = series.Title;
+                    series.Title = details.Title;
+                    series.NeedsRename = true;
+
+                    // Also update all provider titles that still have the truncated name
+                    if (series.Sources != null)
+                    {
+                        foreach (var src2 in series.Sources)
+                        {
+                            if (src2.Title.Length < details.Title.Length)
+                                src2.Title = details.Title;
+                        }
+                    }
+
+                    await _db.SaveChangesAsync(token).ConfigureAwait(false);
+                    _logger.LogInformation("Recovered full title for series {Id}: \"{OldTitle}\" → \"{NewTitle}\"",
+                        series.Id, oldTitle, details.Title);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to recover truncated title for series {Id}", series.Id);
+            }
         }
 
     }

--- a/KaizokuBackend/Services/Series/SeriesExtensions.cs
+++ b/KaizokuBackend/Services/Series/SeriesExtensions.cs
@@ -5,6 +5,7 @@ using KaizokuBackend.Services.Import.Models;
 using KaizokuBackend.Services.Bridge;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Action = KaizokuBackend.Models.Action;
 using Mihon.ExtensionsBridge.Models.Extensions;
@@ -917,6 +918,9 @@ public static class SeriesExtensions
 
     public static void FillSeriesFromProviderSeriesDetails(this DbSeriesEntity dbSeries, ProviderSeriesDetails consolidatedSeries, decimal? startFromChapter)
     {
+        // Title recovery from truncated sources is now handled in SourceInterop.GetDetailsAsync
+        // (HTML meta tag extraction) and SeriesArchiveService.TryRecoverTruncatedTitleAsync
+        // (verify button + periodic checks). Just accept whatever title the provider gives us.
         dbSeries.Title = consolidatedSeries.Title;
         dbSeries.Description = consolidatedSeries.Description ?? string.Empty;
         dbSeries.ThumbnailUrl = consolidatedSeries.ThumbnailUrl ?? string.Empty;

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/ExtensionLoadException.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/ExtensionLoadException.cs
@@ -1,0 +1,12 @@
+namespace Mihon.ExtensionsBridge.Core.Runtime
+{
+    /// <summary>
+    /// Thrown when an extension fails to load due to reflection errors,
+    /// version mismatches, or missing class definitions in the JAR.
+    /// </summary>
+    public class ExtensionLoadException : Exception
+    {
+        public ExtensionLoadException(string message) : base(message) { }
+        public ExtensionLoadException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/JarExtensionInterop.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/JarExtensionInterop.cs
@@ -58,7 +58,18 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
             Version = entry.Extension.Version;
             string className = entry.Extension.Package + entry.ClassName;
             java.util.List ops = null;
-            ops = extension.bridge.Extensions.INSTANCE.loadExtensionSources(jarPath, className);
+            try
+            {
+                ops = extension.bridge.Extensions.INSTANCE.loadExtensionSources(jarPath, className);
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load extension sources for {Package} (class: {ClassName}). " +
+                    "This is likely a Kotlin/Java version mismatch — the extension may require a newer Android.Compat.dll build.",
+                    entry.Extension.Package, className);
+                throw new ExtensionLoadException(
+                    $"Failed to load extension '{entry.Name}' ({entry.Extension.Package}): {ex.Message}", ex);
+            }
             var list = new List<ISourceInterop>();
             ops.toArray().Cast<Source>().ToList().ForEach(s => list.Add(new SourceInterop(s, logger)));
             /*

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
@@ -6,6 +6,7 @@ using eu.kanade.tachiyomi.source.model;
 using Microsoft.Extensions.Logging;
 using okhttp3;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Mihon.ExtensionsBridge.Core.Extensions;
 using Mihon.ExtensionsBridge.Core.Utilities;
 using Mihon.ExtensionsBridge.Models;
@@ -55,8 +56,10 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
 
         /// <summary>
         /// Cached filter list for catalogue queries. Populated on first access.
+        /// Thread-safe via lock to prevent concurrent initialization from parallel searches.
         /// </summary>
-        public eu.kanade.tachiyomi.source.model.FilterList _cachedList = null;
+        private volatile eu.kanade.tachiyomi.source.model.FilterList? _cachedList;
+        private readonly object _filterLock = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SourceInterop"/> class.
@@ -117,6 +120,7 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
 
         /// <summary>
         /// Ensures the catalogue filter list is populated and cached.
+        /// Uses double-checked locking to be safe under concurrent parallel searches.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when the source does not support catalogue operations.</exception>
         private void PopulateFilterList()
@@ -126,7 +130,10 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
 
             if (_cachedList == null)
             {
-                _cachedList = _catalogueSource.getFilterList();
+                lock (_filterLock)
+                {
+                    _cachedList ??= _catalogueSource.getFilterList();
+                }
             }
         }
         public async Task<T> WrapHttpException<T>(Func<Task<T>> func)
@@ -224,8 +231,142 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
                 var mangaDetails = await _httpSource.fetchMangaDetails(mangaImpl).ConsumeObservableOneOrDefaultAsync<SManga>(mangaImpl, token).ConfigureAwait(false);
                 ParsedManga m = mangaDetails!.ToManga<ParsedManga>(manga);
                 m.RealUrl = _httpSource.getMangaUrl(mangaDetails ?? mangaImpl);
+
+                // Many Tachiyomi extensions don't set the title in mangaDetailsParse because the
+                // Tachiyomi app already knows it from search results. However, search results often
+                // contain truncated titles (e.g. "Long Title..."). When detected, fetch the manga
+                // detail page HTML directly and extract the full title from metadata tags.
+                if (IsTitleTruncated(m.Title))
+                {
+                    string recovered = await TryRecoverFullTitleAsync(m.RealUrl, m.Title, token).ConfigureAwait(false);
+                    if (!string.IsNullOrEmpty(recovered))
+                        m.Title = recovered;
+                }
+
                 return m;
             }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Determines whether a title appears to be truncated by the source.
+        /// </summary>
+        private static bool IsTitleTruncated(string? title)
+        {
+            if (string.IsNullOrEmpty(title))
+                return false;
+            return title.EndsWith("...") || title.EndsWith("\u2026"); // Unicode ellipsis
+        }
+
+        /// <summary>
+        /// Attempts to recover the full manga title by fetching the detail page HTML
+        /// and extracting the title from og:title, twitter:title, or the HTML title tag.
+        /// Uses the source's own HTTP client to preserve headers, cookies, and authentication.
+        /// </summary>
+        private async Task<string?> TryRecoverFullTitleAsync(string? pageUrl, string truncatedTitle, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(pageUrl) || _httpSource == null)
+                return null;
+
+            try
+            {
+                Request request = RequestsKt.GET(pageUrl, _httpSource.getHeaders(), CacheControl.FORCE_NETWORK);
+                var response = await Task.Run(() => _httpSource.getClient().newCall(request).execute(), token).ConfigureAwait(false);
+                if (response == null || response.code() != 200)
+                    return null;
+
+                var body = response.body();
+                if (body == null)
+                    return null;
+
+                string html = body.@string();
+                if (string.IsNullOrEmpty(html))
+                    return null;
+
+                // Strip the trailing ellipsis to get the prefix we expect the full title to contain
+                string prefix = truncatedTitle.TrimEnd('.').TrimEnd('\u2026').TrimEnd();
+
+                // Gather all available title sources
+                string?[] rawCandidates = {
+                    ExtractMetaContent(html, "og:title"),
+                    ExtractMetaContent(html, "twitter:title"),
+                    ExtractHtmlTitle(html)
+                };
+
+                // For each candidate, decode HTML entities and extract the substring starting at the prefix.
+                // Site-specific junk (e.g. "[Manga]: ", " Read", " Manga Online for Free") gets stripped
+                // by finding where the known prefix begins and extracting from there.
+                List<string> extractions = new();
+                foreach (var raw in rawCandidates)
+                {
+                    if (string.IsNullOrEmpty(raw))
+                        continue;
+                    string decoded = System.Net.WebUtility.HtmlDecode(raw).Trim();
+                    int idx = decoded.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+                    if (idx >= 0)
+                    {
+                        string extracted = decoded.Substring(idx);
+                        if (extracted.Length > truncatedTitle.Length)
+                            extractions.Add(extracted);
+                    }
+                }
+
+                if (extractions.Count == 0)
+                    return null;
+
+                if (extractions.Count == 1)
+                {
+                    // Single match — return as-is (may have trailing site junk, still better than truncated)
+                    string result = extractions[0].Trim();
+                    return result.Length > truncatedTitle.Length ? result : null;
+                }
+
+                // Multiple matches — find the longest common prefix across all extractions.
+                // This strips trailing site-specific junk that differs between meta tags
+                // (e.g. " Read" vs " Manga Online for Free"), leaving only the real title.
+                string lcp = extractions[0];
+                for (int i = 1; i < extractions.Count; i++)
+                {
+                    int len = Math.Min(lcp.Length, extractions[i].Length);
+                    int j = 0;
+                    while (j < len && char.ToLowerInvariant(lcp[j]) == char.ToLowerInvariant(extractions[i][j]))
+                        j++;
+                    lcp = lcp.Substring(0, j);
+                }
+
+                string recovered = lcp.Trim();
+                return recovered.Length > truncatedTitle.Length ? recovered : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Extracts the content attribute from a meta tag with the given property or name.
+        /// </summary>
+        private static string? ExtractMetaContent(string html, string propertyName)
+        {
+            // Match: <meta property="og:title" content="..."> or <meta name="twitter:title" content="...">
+            // Also handles content before property/name, single quotes, and self-closing tags.
+            var pattern = $@"<meta\s[^>]*?(?:property|name)\s*=\s*[""']{Regex.Escape(propertyName)}[""'][^>]*?content\s*=\s*[""']([^""']+)[""']";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (match.Success)
+                return match.Groups[1].Value;
+
+            // Try reversed attribute order: content before property
+            var reversedPattern = $@"<meta\s[^>]*?content\s*=\s*[""']([^""']+)[""'][^>]*?(?:property|name)\s*=\s*[""']{Regex.Escape(propertyName)}[""']";
+            match = Regex.Match(html, reversedPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+
+        /// <summary>
+        /// Extracts the text content from the HTML title tag.
+        /// </summary>
+        private static string? ExtractHtmlTitle(string html)
+        {
+            var match = Regex.Match(html, @"<title[^>]*>([^<]+)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            return match.Success ? match.Groups[1].Value : null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Recover truncated manga titles using IsTitle-flagged providers
- Sync provider titles when series title already recovered
- Add rename series files endpoint and UI button

## Test plan
- [ ] Verify truncated titles get recovered on sync
- [ ] Confirm only IsTitle providers used for recovery
- [ ] Test rename files endpoint