### PR TITLE
import wizad qol ui fixes

### DIFF
--- a/KaizokuFrontend/pnpm-lock.yaml
+++ b/KaizokuFrontend/pnpm-lock.yaml
@@ -2432,6 +2432,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -3545,6 +3546,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}

--- a/KaizokuFrontend/pnpm-workspace.yaml
+++ b/KaizokuFrontend/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
+allowBuilds:
+  '@tailwindcss/oxide': true
+  kaizoku: true
+  sharp: true
+  unrs-resolver: true
 ignoredBuiltDependencies:
   - kaizoku

--- a/KaizokuFrontend/src/components/kzk/import-wizard/index.tsx
+++ b/KaizokuFrontend/src/components/kzk/import-wizard/index.tsx
@@ -37,7 +37,7 @@ const steps = {
 } satisfies Record<string, StepItem>;
 
 export function ImportWizard() {
-  const { isWizardActive, currentStep, totalSteps, nextStep, previousStep, completeWizard } = useImportWizard();
+  const { isWizardActive, currentStep, totalSteps, nextStep, previousStep, completeWizard, cancelWizard } = useImportWizard();
   const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [canProgress, setCanProgress] = React.useState(false);
@@ -48,11 +48,9 @@ export function ImportWizard() {
   }
 
   return (
-    <Dialog open={true} onOpenChange={() => { /* Prevent closing */ }} modal>
+   <Dialog open={isWizardActive} onOpenChange={(open) => { if (!open) cancelWizard(); }} modal> // we don't need to block this, setup has aleready run. 
       <DialogContent
-        className="w-[98vw] sm:w-[95vw] md:max-w-[90%] lg:max-w-5xl max-h-[95vh] sm:max-h-[90%] flex flex-col overflow-hidden"
-        onInteractOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
+        className="w-[98vw] sm:w-[95vw] md:max-w-[90%] lg:max-w-5xl max-h-[95vh] sm:max-h-[90%] flex flex-col overflow-auto"// changed overflow-hidden to auto for better handling of content that exceeds viewport height
       >
         <DialogHeader>
           <DialogTitle>Import Wizard</DialogTitle>
@@ -172,7 +170,7 @@ function Footer({ currentStep, totalSteps, canProgress, isLoading, onNext, onPre
   const isLastStep = currentStep === totalSteps - 1;
 
   return (
-    <div className="flex flex-col-reverse sm:flex-row sm:justify-between items-center gap-3 sm:gap-2 pt-4 border-t sm:border-t-0">
+    <div className="flex flex-col-reverse sm:flex-row sm:justify-between items-center gap-3 sm:gap-2 pt-4 border-t sm:border-t-0 overflow-visible"> //prevent clipping of button
       <Button
         variant="outline"
         onClick={onPrevious}

--- a/KaizokuFrontend/src/components/kzk/setup-wizard/steps/finish-step.tsx
+++ b/KaizokuFrontend/src/components/kzk/setup-wizard/steps/finish-step.tsx
@@ -156,7 +156,7 @@ export function FinishStep({ setError, setIsLoading, setCanProgress, disableDown
 
       <div 
         ref={containerRef}
-        className={`max-h-[60vh] p-0.5 overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
+        className={`max-h-[30vh] p-0.5 overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
       >
         <div className="space-y-6">
           <Card className={`w-full ${isActive ? 'ring-2 ring-primary' : ''}`}>

--- a/KaizokuFrontend/src/components/kzk/setup-wizard/steps/import-local-step.tsx
+++ b/KaizokuFrontend/src/components/kzk/setup-wizard/steps/import-local-step.tsx
@@ -225,7 +225,7 @@ export function ImportLocalStep({ setError, setIsLoading, setCanProgress }: Impo
 
       <div
         ref={containerRef}
-        className={`max-h-[60vh] p-0.5 overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
+        className={`max-h-[30vh] p-0.5 overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
       >
         <div className="space-y-4">
           <h3 className="text-lg font-medium">Import Progress</h3>

--- a/KaizokuFrontend/src/components/kzk/setup-wizard/steps/preferences-step.tsx
+++ b/KaizokuFrontend/src/components/kzk/setup-wizard/steps/preferences-step.tsx
@@ -85,7 +85,7 @@ export function PreferencesStep({
         These settings can be changed later in the Settings page.
       </div>      <div 
         ref={containerRef}
-        className={`max-h-[60vh] overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
+        className={`max-h-[30vh] overflow-y-auto ${hasScrollbar ? 'pr-2' : ''}`}
       >
         <SettingsManager
           sections={[

--- a/KaizokuFrontend/src/components/ui/dialog.tsx
+++ b/KaizokuFrontend/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-[95vw] sm:w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-3 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto overflow-x-hidden",
+        "fixed left-[50%] top-[50%] z-50 grid w-[95vw] sm:w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-3 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg max-h-[95vh] sm:max-h-[90vh] overflow-y-auto overflow-x-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
	modified:   KaizokuFrontend/pnpm-lock.yaml
	modified:   KaizokuFrontend/pnpm-workspace.yaml
	modified:   KaizokuFrontend/src/components/kzk/import-wizard/index.tsx
	modified:   KaizokuFrontend/src/components/kzk/setup-wizard/steps/finish-step.tsx
	modified:   KaizokuFrontend/src/components/kzk/setup-wizard/steps/import-local-step.tsx
	modified:   KaizokuFrontend/src/components/kzk/setup-wizard/steps/preferences-step.tsx
	modified:   KaizokuFrontend/src/components/ui/dialog.tsx
Edited dialogues to allow for horizontal scroll in long name series adder, added close button
For the importer, and to prevent clipping of the next step in the import wizard for smaller screens. 
Also changed height to allow for smaller resolutions to actually scroll to the bottom. 