### PR TITLE
feat(series): Rename action — canonical series folder and .cbz filenames

### DIFF
--- a/RensaioBackend/Controllers/SeriesController.cs
+++ b/RensaioBackend/Controllers/SeriesController.cs
@@ -160,6 +160,33 @@ namespace RensaioBackend.Controllers
         }
 
         /// <summary>
+        /// Renames the series folder to match its current title and renames every downloaded
+        /// .cbz to the canonical naming scheme. Repairs archives saved under an out-of-date name.
+        /// </summary>
+        /// <param name="id">The unique identifier of the series.</param>
+        /// <param name="token">Cancellation token.</param>
+        [HttpPost("rename")]
+        [RequireUserLevel(UserLevel.Manager)]
+        [ProducesResponseType(typeof(SeriesRenameResultDto), 200)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(500)]
+        public async Task<ActionResult<SeriesRenameResultDto>> RenameSeriesAsync([FromQuery] Guid id, CancellationToken token = default)
+        {
+            try
+            {
+                if (id == Guid.Empty)
+                    return BadRequest("No series id provided");
+                var result = await _archiveService.RenameSeriesAsync(id, token).ConfigureAwait(false);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error renaming series: {Message}", ex.Message);
+                return StatusCode(500, "Error renaming series.");
+            }
+        }
+
+        /// <summary>
         /// Gets the unified, series-level chapter list (merged across every source). Each chapter
         /// reports whether it is downloaded and from which source, versus genuinely missing, plus the
         /// sources available for (re-)download.

--- a/RensaioBackend/Models/Dto/SeriesRenameResultDto.cs
+++ b/RensaioBackend/Models/Dto/SeriesRenameResultDto.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace RensaioBackend.Models.Dto;
+
+/// <summary>
+/// Result of a series rename operation: renaming the series folder to match the
+/// current title and renaming each downloaded .cbz to the canonical naming scheme.
+/// </summary>
+public class SeriesRenameResultDto
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    /// <summary>True when the series folder was renamed on disk.</summary>
+    [JsonPropertyName("folderRenamed")]
+    public bool FolderRenamed { get; set; }
+
+    /// <summary>Relative storage path before the rename.</summary>
+    [JsonPropertyName("oldFolder")]
+    public string OldFolder { get; set; } = string.Empty;
+
+    /// <summary>Relative storage path after the rename (unchanged if folder was not renamed).</summary>
+    [JsonPropertyName("newFolder")]
+    public string NewFolder { get; set; } = string.Empty;
+
+    /// <summary>Number of .cbz archives renamed to the canonical scheme.</summary>
+    [JsonPropertyName("filesRenamed")]
+    public int FilesRenamed { get; set; }
+
+    /// <summary>Number of archives that could not be renamed (e.g. target name already taken).</summary>
+    [JsonPropertyName("filesFailed")]
+    public int FilesFailed { get; set; }
+
+    /// <summary>Optional human-readable note (e.g. why the folder rename was skipped).</summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}

--- a/RensaioBackend/Services/Downloads/DownloadCommandService.cs
+++ b/RensaioBackend/Services/Downloads/DownloadCommandService.cs
@@ -147,7 +147,7 @@ namespace RensaioBackend.Services.Downloads
             if (p != null)
                 maxChap = p.Chapters.Max(c => c.Number);
 
-            string zipFile = ArchiveHelperService.MakeFileNameSafe(ch.ProviderName, ch.Scanlator, ch.SeriesTitle, ch.Language, ch.Chapter.ParsedNumber, rchap, maxChap) + ".cbz";
+            string zipFile = ArchiveHelperService.MakeFileNameSafe(ch.ProviderName, ch.Scanlator, ch.Title, ch.Language, ch.Chapter.ParsedNumber, rchap, maxChap) + ".cbz";
             string message = $"Downloading ({providerName}) {ch.Title} {chapterName}...";
             await reporter.ReportAsync(ProgressStatus.Started, 0, message, downloadSummary, null, token).ConfigureAwait(false);
 
@@ -192,7 +192,7 @@ namespace RensaioBackend.Services.Downloads
                                     _logger.LogWarning("Page {Page} of chapter {ChapterNumber} of series {SeriesTitle} is not a valid image", pageIndex + 1, ch.Chapter.ParsedNumber, ch.Title);
                                     ext = ".unk";
                                 }
-                                string fileName = ArchiveHelperService.MakeFileNameSafe(ch.ProviderName, ch.Scanlator, ch.SeriesTitle, ch.Language,
+                                string fileName = ArchiveHelperService.MakeFileNameSafe(ch.ProviderName, ch.Scanlator, ch.Title, ch.Language,
                                             ch.Chapter.ParsedNumber, ch.ChapterName, maxChap, pageIndex + 1, ch.PageCount) + ext;
                                 await zipWriter.WriteAsync(fileName, image).ConfigureAwait(false);
                                 pagesWritten++;

--- a/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
+++ b/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
@@ -411,6 +411,23 @@ namespace RensaioBackend.Services.Helpers
             return safeName;
         }
 
+        /// <summary>
+        /// Builds the leading "[Provider][lang]" portion that <see cref="MakeFileNameSafe"/> writes
+        /// at the start of every archive it names, applying the identical provider/scanlator
+        /// normalization (dash → underscore, scanlator suffix, bracket escaping). Use this to
+        /// recognize Rensaio-named archives — regardless of how a scanlator suffix or escaped
+        /// character changed the on-disk spelling — rather than guessing from the raw provider name.
+        /// </summary>
+        public static string MakeFileNamePrefixSafe(string provider, string? scanlator, string language)
+        {
+            provider = provider.Replace("-", "_");
+            if (scanlator != null && provider != scanlator)
+                provider += "-" + scanlator;
+            provider = provider.Replace("[", "(").Replace("]", ")");
+            string lan = !string.IsNullOrEmpty(language) ? "[" + language.ToLowerInvariant() + "]" : "";
+            return $"[{provider}]{lan}".ReplaceInvalidFilenameAndPathCharacters();
+        }
+
         public static ComicInfo CreateComicInfo(Models.Database.SeriesEntity s, SeriesProviderEntity sp, Chapter chap, int cnt)
         {
             List<string> ratings = Enum.GetNames<AgeRating>().ToList();

--- a/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
+++ b/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
@@ -425,7 +425,11 @@ namespace RensaioBackend.Services.Helpers
                 provider += "-" + scanlator;
             provider = provider.Replace("[", "(").Replace("]", ")");
             string lan = !string.IsNullOrEmpty(language) ? "[" + language.ToLowerInvariant() + "]" : "";
-            return $"[{provider}]{lan}".ReplaceInvalidFilenameAndPathCharacters();
+            string prefix = $"[{provider}]{lan}".ReplaceInvalidFilenameAndPathCharacters();
+            // Mirror MakeFileNameSafe's whitespace collapse so this prefix StartsWith-matches
+            // the names it produces.
+            prefix = Regex.Replace(prefix, @"\s+", " ").Trim();
+            return prefix;
         }
 
         public static ComicInfo CreateComicInfo(Models.Database.SeriesEntity s, SeriesProviderEntity sp, Chapter chap, int cnt)

--- a/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
+++ b/RensaioBackend/Services/Helpers/ArchiveHelperService.cs
@@ -455,8 +455,8 @@ namespace RensaioBackend.Services.Helpers
             info.LanguageISO = sp.Language.ToLowerInvariant();
             info.Number = chap.Number?.FormatDecimal() ?? "";
             info.PageCount = cnt;
-            info.Series = sp.Title.Trim();
-            info.LocalizedSeries = s.Title.Trim();
+            info.Series = s.Title.Trim();
+            info.LocalizedSeries = sp.Title.Trim();
             info.Web = chap.Url!;
             info.Writer = sp.Author?.Trim() ?? s.Author?.Trim() ?? "";
             info.Publisher = sp.Provider;

--- a/RensaioBackend/Services/Series/SeriesArchiveService.cs
+++ b/RensaioBackend/Services/Series/SeriesArchiveService.cs
@@ -143,6 +143,162 @@ namespace RensaioBackend.Services.Series
         }
 
         /// <summary>
+        /// Renames the series folder to match the current title and renames every downloaded
+        /// .cbz to the canonical "[Provider][lang] Title NNNN" scheme. This repairs archives
+        /// that were saved under an out-of-date name (e.g. a title that was later corrected, or
+        /// a chapter-number padding width that grew) without manual per-file renaming.
+        /// Only the leaf folder is renamed — any existing parent (such as a type subfolder) is kept.
+        /// </summary>
+        /// <param name="seriesId">The series ID to rename.</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>A summary of what was renamed.</returns>
+        public async Task<SeriesRenameResultDto> RenameSeriesAsync(Guid seriesId, CancellationToken token = default)
+        {
+            SettingsDto settings = await _settings.GetSettingsAsync(token).ConfigureAwait(false);
+            Models.Database.SeriesEntity? series = await _db.Series.Include(a => a.Sources)
+                .Where(a => a.Id == seriesId).FirstOrDefaultAsync(token).ConfigureAwait(false);
+
+            if (series == null)
+                throw new ArgumentException("Invalid series Id");
+
+            var result = new SeriesRenameResultDto { OldFolder = series.StoragePath };
+
+            // ── 1. Rename each archive to the canonical scheme (within the current folder) ──
+            string basePath = Path.Combine(settings.StorageFolder, series.StoragePath);
+            bool dbChanged = false;
+
+            foreach (SeriesProviderEntity sp in series.Sources)
+            {
+                // Only touch archives we own: Rensaio-downloaded files start with [Provider][lang].
+                // This leaves manually imported / foreign files untouched.
+                string prefix = $"[{sp.Provider}][{sp.Language}]";
+
+                foreach (Chapter chap in sp.Chapters.Where(c => !string.IsNullOrEmpty(c.Filename)))
+                {
+                    if (!chap.Filename!.StartsWith(prefix, StringComparison.Ordinal))
+                        continue;
+
+                    string extension = Path.GetExtension(chap.Filename);
+                    if (string.IsNullOrEmpty(extension))
+                        extension = ".cbz";
+
+                    string newFileName = ArchiveHelperService.MakeFileNameSafe(
+                        sp.Provider, sp.Scanlator, sp.Title, sp.Language,
+                        chap.Number, chap.Name, sp.ChapterCount) + extension;
+
+                    if (string.Equals(newFileName, chap.Filename, StringComparison.Ordinal))
+                        continue;
+
+                    string oldFullPath = Path.Combine(basePath, chap.Filename);
+                    string newFullPath = Path.Combine(basePath, newFileName);
+
+                    if (!File.Exists(oldFullPath))
+                        continue;
+
+                    // Refuse to clobber an unrelated existing file (case-only renames resolve to the
+                    // same path and are allowed to fall through to File.Move).
+                    if (File.Exists(newFullPath) &&
+                        !string.Equals(oldFullPath, newFullPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogWarning("Skipping rename of {Old}: target {New} already exists",
+                            oldFullPath, newFullPath);
+                        result.FilesFailed++;
+                        continue;
+                    }
+
+                    try
+                    {
+                        // Hashes are keyed by filename, so drop the stale entry before moving.
+                        _hashCache.DeleteChapterHash(series.StoragePath, chap.Filename);
+                        File.Move(oldFullPath, newFullPath);
+                        _logger.LogInformation("Renamed archive {Old} -> {New}", chap.Filename, newFileName);
+                        chap.Filename = newFileName;
+                        _db.Touch(sp, a => a.Chapters);
+                        dbChanged = true;
+                        result.FilesRenamed++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to rename archive {Old} to {New}", oldFullPath, newFullPath);
+                        result.FilesFailed++;
+                    }
+                }
+            }
+
+            if (dbChanged)
+                await _db.SaveChangesAsync(token).ConfigureAwait(false);
+
+            // ── 2. Rename the series folder leaf to match the title (parent structure preserved) ──
+            string parentRel = Path.GetDirectoryName(series.StoragePath) ?? string.Empty;
+            string safeLeaf = series.Title.MakeFolderNameSafe();
+            string desiredRel = SeriesModelExtensions.NormalizeStoragePath(
+                string.IsNullOrEmpty(parentRel) ? safeLeaf : Path.Combine(parentRel, safeLeaf));
+
+            if (!string.Equals(series.StoragePath, desiredRel, StringComparison.Ordinal))
+            {
+                string oldAbs = Path.Combine(settings.StorageFolder, series.StoragePath);
+                string newAbs = Path.Combine(settings.StorageFolder, desiredRel);
+                bool caseOnly = string.Equals(series.StoragePath, desiredRel, StringComparison.OrdinalIgnoreCase);
+
+                if (!Directory.Exists(oldAbs))
+                {
+                    result.Message = "Series folder not found on disk; skipped folder rename.";
+                }
+                else if (!caseOnly && Directory.Exists(newAbs))
+                {
+                    result.Message = $"Target folder '{desiredRel}' already exists; skipped folder rename.";
+                    _logger.LogWarning("Cannot rename folder for series {Id}: target {New} exists", seriesId, newAbs);
+                }
+                else
+                {
+                    try
+                    {
+                        string? parentAbs = Path.GetDirectoryName(newAbs);
+                        if (!string.IsNullOrEmpty(parentAbs) && !Directory.Exists(parentAbs))
+                            Directory.CreateDirectory(parentAbs);
+
+                        if (caseOnly)
+                        {
+                            // Two-step move so case-only renames also work on case-insensitive filesystems.
+                            string tempAbs = newAbs + "__rename_tmp";
+                            Directory.Move(oldAbs, tempAbs);
+                            Directory.Move(tempAbs, newAbs);
+                        }
+                        else
+                        {
+                            Directory.Move(oldAbs, newAbs);
+                        }
+
+                        series.StoragePath = desiredRel;
+                        await _db.SaveChangesAsync(token).ConfigureAwait(false);
+                        result.FolderRenamed = true;
+                        _logger.LogInformation("Renamed series folder {Old} -> {New}", oldAbs, newAbs);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to rename series folder {Old} to {New}", oldAbs, newAbs);
+                        result.Message = "Failed to rename series folder; see logs for details.";
+                    }
+                }
+            }
+
+            result.NewFolder = series.StoragePath;
+
+            // ── 3. Re-sync canonical state to rensaio.json under the final folder ──
+            try
+            {
+                await _stateService.SyncToRensaioJsonAsync(series.Id, token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to sync rensaio.json after rename for series {SeriesId}", series.Id);
+            }
+
+            result.Success = true;
+            return result;
+        }
+
+        /// <summary>
         /// Cleans up corrupted series files and marks chapters for re-download
         /// </summary>
         /// <param name="seriesId">The series ID to cleanup</param>

--- a/RensaioBackend/Services/Series/SeriesArchiveService.cs
+++ b/RensaioBackend/Services/Series/SeriesArchiveService.cs
@@ -221,7 +221,20 @@ namespace RensaioBackend.Services.Series
                     {
                         // Hashes are keyed by filename, so drop the stale entry before moving.
                         _hashCache.DeleteChapterHash(series.StoragePath, chap.Filename);
-                        File.Move(oldFullPath, newFullPath);
+                        if (!string.Equals(oldFullPath, newFullPath, StringComparison.Ordinal) &&
+                            string.Equals(oldFullPath, newFullPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Case-only rename: a direct File.Move throws "already exists" on
+                            // case-insensitive filesystems, so hop through a temp name first
+                            // (same two-step pattern the folder rename below uses).
+                            string tempFullPath = newFullPath + "__rename_tmp";
+                            File.Move(oldFullPath, tempFullPath);
+                            File.Move(tempFullPath, newFullPath);
+                        }
+                        else
+                        {
+                            File.Move(oldFullPath, newFullPath);
+                        }
                         _logger.LogInformation("Renamed archive {Old} -> {New}", chap.Filename, newFileName);
                         chap.Filename = newFileName;
                         _db.Touch(sp, a => a.Chapters);
@@ -273,7 +286,24 @@ namespace RensaioBackend.Services.Series
                             // Two-step move so case-only renames also work on case-insensitive filesystems.
                             string tempAbs = newAbs + "__rename_tmp";
                             Directory.Move(oldAbs, tempAbs);
-                            Directory.Move(tempAbs, newAbs);
+                            try
+                            {
+                                Directory.Move(tempAbs, newAbs);
+                            }
+                            catch
+                            {
+                                // Second leg failed: roll the folder back to its original name so
+                                // it is never stranded at the temp path, then rethrow for the outer handler.
+                                try
+                                {
+                                    Directory.Move(tempAbs, oldAbs);
+                                }
+                                catch (Exception rollbackEx)
+                                {
+                                    _logger.LogError(rollbackEx, "Failed to roll back temp folder {Temp} to {Old} after a failed case-only folder rename", tempAbs, oldAbs);
+                                }
+                                throw;
+                            }
                         }
                         else
                         {

--- a/RensaioBackend/Services/Series/SeriesArchiveService.cs
+++ b/RensaioBackend/Services/Series/SeriesArchiveService.cs
@@ -169,9 +169,17 @@ namespace RensaioBackend.Services.Series
 
             foreach (SeriesProviderEntity sp in series.Sources)
             {
-                // Only touch archives we own: Rensaio-downloaded files start with [Provider][lang].
-                // This leaves manually imported / foreign files untouched.
-                string prefix = $"[{sp.Provider}][{sp.Language}]";
+                // Only touch archives we own: Rensaio names every file it writes
+                // "[Provider][lang] Title NNNN". Rebuild that prefix with the same provider/
+                // scanlator normalization MakeFileNameSafe applies, so the check still matches when
+                // a scanlator suffix or an escaped character changed the on-disk spelling (e.g.
+                // "[MangaGeko-][en] ..."). Manually imported / foreign files keep their own names.
+                string prefix = ArchiveHelperService.MakeFileNamePrefixSafe(sp.Provider, sp.Scanlator, sp.Language);
+
+                // Pad chapter numbers against the highest chapter present, exactly like the
+                // downloader does — so renaming reproduces the canonical width and repairs padding
+                // that grew (e.g. "5" -> "005" after the series passed 100 chapters).
+                decimal? maxChap = sp.Chapters.Max(c => c.Number);
 
                 foreach (Chapter chap in sp.Chapters.Where(c => !string.IsNullOrEmpty(c.Filename)))
                 {
@@ -182,9 +190,12 @@ namespace RensaioBackend.Services.Series
                     if (string.IsNullOrEmpty(extension))
                         extension = ".cbz";
 
+                    // Use the series-level (canonical) title so files from every source converge on
+                    // the title the user chose via "Use as title" — not each source's own title,
+                    // which would just reproduce the existing name and rename nothing.
                     string newFileName = ArchiveHelperService.MakeFileNameSafe(
-                        sp.Provider, sp.Scanlator, sp.Title, sp.Language,
-                        chap.Number, chap.Name, sp.ChapterCount) + extension;
+                        sp.Provider, sp.Scanlator, series.Title, sp.Language,
+                        chap.Number, chap.Name, maxChap) + extension;
 
                     if (string.Equals(newFileName, chap.Filename, StringComparison.Ordinal))
                         continue;

--- a/RensaioBackend/Services/Series/SeriesCommandService.cs
+++ b/RensaioBackend/Services/Series/SeriesCommandService.cs
@@ -502,8 +502,13 @@ namespace RensaioBackend.Services.Series
                     SeriesStatus newStatus = (SeriesStatus)(int)extensionManga.Status;
                     bool statusChanged = newStatus != serie.LastKnownStatus;
 
-                    // Update the series-level metadata
-                    if (!string.IsNullOrEmpty(extensionManga.Title))
+                    // Update the series-level metadata.
+                    // Only the provider flagged as the title source may overwrite the canonical
+                    // series title; otherwise a per-provider refresh would clobber the selected
+                    // title with whichever provider refreshed last. When no provider is flagged
+                    // as the title source, preserve the upstream behaviour of taking the title.
+                    if (!string.IsNullOrEmpty(extensionManga.Title) &&
+                        (serie.IsTitle || !series.Sources.Any(x => x.IsTitle)))
                         series.Title = extensionManga.Title;
                     if (!string.IsNullOrEmpty(extensionManga.Artist))
                         series.Artist = extensionManga.Artist;

--- a/RensaioBackend/Services/Series/SeriesCommandService.cs
+++ b/RensaioBackend/Services/Series/SeriesCommandService.cs
@@ -872,18 +872,49 @@ namespace RensaioBackend.Services.Series
 
         private static void UpdateProviderSettings(SeriesExtendedDto series, Models.Database.SeriesEntity dbSeries)
         {
+            SeriesProviderEntity? newTitle = null;
+            SeriesProviderEntity? newCover = null;
             foreach (ProviderExtendedDto p in series.Providers)
             {
                 SeriesProviderEntity? n = dbSeries.Sources.FirstOrDefault(a => a.Id == p.Id);
                 if (n == null)
                     continue;
-                
+
                 n.IsDisabled = p.IsDisabled;
                 n.IsStorage = p.IsStorage;
+                if (p.UseTitle && !n.IsTitle)
+                    newTitle = n;
+                if (p.UseCover && !n.IsCover)
+                    newCover = n;
                 n.IsTitle = p.UseTitle;
                 n.IsCover = p.UseCover;
                 n.IsLocal = p.IsLocal;
                 n.ContinueAfterChapter = p.ContinueAfterChapter;
+            }
+
+            // Title/cover selection is exclusive. A stale or partial DTO can leave several
+            // sources flagged at once, and consolidation would then keep whichever source
+            // enumerates first instead of the user's pick. Keep only one: the source that
+            // just turned on, or for pre-existing duplicates the one matching the current
+            // series value.
+            List<SeriesProviderEntity> titled = dbSeries.Sources.Where(a => a.IsTitle).ToList();
+            if (titled.Count > 1)
+            {
+                SeriesProviderEntity keep = newTitle
+                    ?? titled.FirstOrDefault(a => a.Title == dbSeries.Title)
+                    ?? titled[0];
+                foreach (SeriesProviderEntity sp in titled)
+                    sp.IsTitle = sp == keep;
+            }
+
+            List<SeriesProviderEntity> covered = dbSeries.Sources.Where(a => a.IsCover).ToList();
+            if (covered.Count > 1)
+            {
+                SeriesProviderEntity keep = newCover
+                    ?? covered.FirstOrDefault(a => a.ThumbnailUrl == dbSeries.ThumbnailUrl)
+                    ?? covered[0];
+                foreach (SeriesProviderEntity sp in covered)
+                    sp.IsCover = sp == keep;
             }
         }
 

--- a/RensaioBackend/Services/Series/SeriesExtensions.cs
+++ b/RensaioBackend/Services/Series/SeriesExtensions.cs
@@ -950,7 +950,10 @@ public static class SeriesExtensions
         dbSeries.Artist = consolidatedSeries.Artist ?? string.Empty;
         dbSeries.Author = consolidatedSeries.Author ?? string.Empty;
         dbSeries.Genre = consolidatedSeries.Genre ?? new List<string>();
-        dbSeries.Type = consolidatedSeries.Type;
+        // The entity-list consolidation never carries Type (providers don't store it),
+        // so a null here means "unknown" — keep the value detected at import/search time.
+        if (consolidatedSeries.Type != null)
+            dbSeries.Type = consolidatedSeries.Type;
         dbSeries.StartFromChapter = startFromChapter;
         int normalizedChapterCount = SeriesModelExtensions.ClampChapterCount(consolidatedSeries.ChapterCount);
         if (normalizedChapterCount > dbSeries.ChapterCount)

--- a/RensaioBackend/Services/Series/SeriesProviderService.cs
+++ b/RensaioBackend/Services/Series/SeriesProviderService.cs
@@ -164,7 +164,7 @@ namespace RensaioBackend.Services.Series
                     string? extension = Path.GetExtension(ch.Filename);
                     decimal? maxChap = targetProvider.Chapters.Max(c => c.Number);
                     string filename = ArchiveHelperService.MakeFileNameSafe(targetProvider.Provider, targetProvider.Scanlator,
-                        targetProvider.Title, targetProvider.Language, ch.Number, ch.Name, maxChap);
+                        series.Title, targetProvider.Language, ch.Number, ch.Name, maxChap);
                     string newFilename = filename + extension;
                     string originalPath = Path.Combine(settings.StorageFolder, series.StoragePath, ch.Filename ?? "");
                     string newPath = Path.Combine(settings.StorageFolder, series.StoragePath, newFilename);
@@ -192,7 +192,7 @@ namespace RensaioBackend.Services.Series
                     {
                         decimal? maxChap = targetProvider.Chapters.Max(c => c.Number);
                         string filename = ArchiveHelperService.MakeFileNameSafe(targetProvider.Provider, targetProvider.Scanlator,
-                            targetProvider.Title, targetProvider.Language, dst.Number, dst.Name, maxChap);
+                            series.Title, targetProvider.Language, dst.Number, dst.Name, maxChap);
                         string? extension = Path.GetExtension(ch.Filename);
                         string newFilename = filename + extension;
                         string originalPath = Path.Combine(settings.StorageFolder, series.StoragePath, ch.Filename ?? "");

--- a/RensaioFrontend/src/app/library/series/page.tsx
+++ b/RensaioFrontend/src/app/library/series/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams, useRouter } from "next/navigation";
 import { useState, useEffect, useRef, Suspense } from "react";
-import { useSeriesById, useDeleteSeries, useUpdateSeries, useVerifyIntegrity, useCleanupSeries, useRefreshSeries } from "@/lib/api/hooks/useSeries";
+import { useSeriesById, useDeleteSeries, useUpdateSeries, useVerifyIntegrity, useCleanupSeries, useRefreshSeries, useRenameSeries } from "@/lib/api/hooks/useSeries";
 import { useToast } from "@/hooks/use-toast";
 import { seriesService } from "@/lib/api/services/seriesService";
 import { useQueryClient } from '@tanstack/react-query';
@@ -17,7 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Trash2, ShieldCheck } from "lucide-react";
+import { Trash2, ShieldCheck, FolderSync } from "lucide-react";
 import { SeriesStatus, ArchiveResult, type ExistingSource, type SeriesExtendedInfo, type SeriesIntegrityResult } from "@/lib/api/types";
 import { useSeriesContext } from "@/contexts/series-context";
 
@@ -60,6 +60,7 @@ function SeriesPageContent() {
   const verifyIntegrity = useVerifyIntegrity();
   const cleanupSeries = useCleanupSeries();
   const refreshSeries = useRefreshSeries();
+  const renameSeries = useRenameSeries();
   const { toast } = useToast();
   
   // Provider switch state management
@@ -81,6 +82,9 @@ function SeriesPageContent() {
   const [showVerifyDialog, setShowVerifyDialog] = useState(false);
   const [verifyResult, setVerifyResult] = useState<SeriesIntegrityResult | null>(null);
   const [showCleanupDialog, setShowCleanupDialog] = useState(false);
+
+  // Rename (fix folder + .cbz names) confirmation dialog state
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
   
   // Track user activity for periodic refresh logic
   const lastActivityRef = useRef<number>(Date.now());
@@ -857,6 +861,46 @@ function SeriesPageContent() {
     }
   };
 
+  // Handler for the rename button — opens a confirmation dialog first, since this
+  // moves files/folders on disk.
+  const handleRenameClick = () => {
+    if (!seriesId) return;
+    setShowRenameDialog(true);
+  };
+
+  // Handler for rename confirmation — renames the series folder + every .cbz to the
+  // canonical naming scheme, then reports the outcome.
+  const handleRenameConfirm = async () => {
+    if (!seriesId) return;
+    setShowRenameDialog(false);
+
+    try {
+      const result = await renameSeries.mutateAsync(seriesId);
+
+      const parts: string[] = [];
+      if (result.folderRenamed) parts.push(`Folder → "${result.newFolder}"`);
+      parts.push(`${result.filesRenamed} file${result.filesRenamed === 1 ? '' : 's'} renamed`);
+      if (result.filesFailed > 0) parts.push(`${result.filesFailed} failed`);
+
+      const nothingChanged = !result.folderRenamed && result.filesRenamed === 0 && result.filesFailed === 0;
+
+      toast({
+        variant: result.filesFailed > 0 ? "destructive" : "success",
+        title: nothingChanged ? "Names already correct" : "Rename complete",
+        description: nothingChanged
+          ? (result.message || "Nothing needed renaming — everything already matches the scheme.")
+          : `${parts.join(' · ')}${result.message ? ` · ${result.message}` : ''}`,
+      });
+    } catch (error) {
+      console.error('Failed to rename series:', error);
+      toast({
+        variant: "destructive",
+        title: "Rename failed",
+        description: "Could not rename the series files. Please try again.",
+      });
+    }
+  };
+
   // Handler for verify success dialog close
   const handleVerifyDialogClose = async () => {
     setShowVerifyDialog(false);
@@ -1138,9 +1182,11 @@ function SeriesPageContent() {
         canManageDownloads={canManageDownloads}
         verifyPending={verifyIntegrity.isPending}
         refreshPending={refreshSeries.isPending}
+        renamePending={renameSeries.isPending}
         onPauseToggle={handlePausedDownloadsToggle}
         onVerify={handleVerifyIntegrityClick}
         onRefresh={handleRefreshClick}
+        onRename={handleRenameClick}
         onDelete={handleDeleteSeriesClick}
       />
 
@@ -1222,6 +1268,51 @@ function SeriesPageContent() {
               <>
                 <Trash2 className="h-4 w-4" />
                 Delete
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    {/* Rename (fix folder + .cbz names) Confirmation Dialog */}
+    <Dialog open={showRenameDialog} onOpenChange={setShowRenameDialog}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderSync className="h-5 w-5" />
+            Rename Files &amp; Folder
+          </DialogTitle>
+          <DialogDescription>
+            This renames the series folder to <span className="font-medium text-foreground">"{displayTitle}"</span> and
+            renames every downloaded <span className="font-mono">.cbz</span> to the correct
+            <span className="font-mono"> [Source][lang] Title 0000.cbz</span> scheme. Only files downloaded by
+            Rensaio are touched. This moves files on disk — make sure no downloads are running for this series.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+          <Button
+            variant="outline"
+            onClick={() => setShowRenameDialog(false)}
+            disabled={renameSeries.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleRenameConfirm}
+            disabled={renameSeries.isPending}
+            className="flex items-center gap-2"
+          >
+            {renameSeries.isPending ? (
+              <>
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-background border-t-transparent" />
+                Renaming...
+              </>
+            ) : (
+              <>
+                <FolderSync className="h-4 w-4" />
+                Rename
               </>
             )}
           </Button>

--- a/RensaioFrontend/src/app/library/series/page.tsx
+++ b/RensaioFrontend/src/app/library/series/page.tsx
@@ -1101,6 +1101,11 @@ function SeriesPageContent() {
       }
     } catch (error) {
       console.error(`Error updating series with complete state:`, error);
+      toast({
+        title: "Failed to save series settings",
+        description: "Your change was not saved. Please try again.",
+        variant: "destructive",
+      });
     }
   };
   

--- a/RensaioFrontend/src/components/comp/series/detail/series-hero.tsx
+++ b/RensaioFrontend/src/components/comp/series/detail/series-hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pause, Play, CheckCircle2, Check, Trash2, FolderOpen, Copy, RefreshCw } from "lucide-react";
+import { Pause, Play, CheckCircle2, Check, Trash2, FolderOpen, Copy, RefreshCw, FolderSync } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SeriesStatus, type SeriesExtendedInfo } from "@/lib/api/types";
 import { formatThumbnailUrl } from "@/lib/utils/thumbnail";
@@ -126,9 +126,11 @@ export interface SeriesHeroProps {
   canManageDownloads: boolean;
   verifyPending: boolean;
   refreshPending: boolean;
+  renamePending: boolean;
   onPauseToggle: () => void;
   onVerify: () => void;
   onRefresh: () => void;
+  onRename: () => void;
   onDelete: () => void;
 }
 
@@ -143,9 +145,11 @@ export function SeriesHero({
   canManageDownloads,
   verifyPending,
   refreshPending,
+  renamePending,
   onPauseToggle,
   onVerify,
   onRefresh,
+  onRename,
   onDelete,
 }: SeriesHeroProps) {
   const [expanded, setExpanded] = useState(false);
@@ -325,6 +329,19 @@ export function SeriesHero({
                 >
                   <RefreshCw className={`h-4 w-4 sm:mr-2 ${refreshPending ? 'animate-spin' : ''}`} />
                   <span className="hidden sm:inline">Refresh</span>
+                </Button>
+              )}
+
+              {canEditSeries && (
+                <Button
+                  variant="outline"
+                  onClick={onRename}
+                  disabled={renamePending}
+                  title="Rename the series folder & all .cbz files to the correct naming scheme"
+                  className="px-0 w-9 sm:w-auto sm:px-4"
+                >
+                  <FolderSync className={`h-4 w-4 sm:mr-2 ${renamePending ? 'animate-spin' : ''}`} />
+                  <span className="hidden sm:inline">Rename</span>
                 </Button>
               )}
 

--- a/RensaioFrontend/src/lib/api/hooks/useSeries.ts
+++ b/RensaioFrontend/src/lib/api/hooks/useSeries.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { seriesService } from '@/lib/api/services/seriesService';
-import { type FullSeries, type SeriesInfo, type SeriesExtendedInfo, type ProviderMatch, type AugmentedResponse, type LatestSeriesInfo, type LatestGenre, type SearchSource, type SeriesIntegrityResult, type ChapterDetail } from '@/lib/api/types';
+import { type FullSeries, type SeriesInfo, type SeriesExtendedInfo, type ProviderMatch, type AugmentedResponse, type LatestSeriesInfo, type LatestGenre, type SearchSource, type SeriesIntegrityResult, type SeriesRenameResult, type ChapterDetail } from '@/lib/api/types';
 
 /**
  * Hook to get available search sources (for search and filtering)
@@ -221,6 +221,22 @@ export const useRefreshSeries = () => {
     onSuccess: (_, id) => {
       // The refresh runs asynchronously on the backend; invalidate so the detail
       // (and library tab counts) pick up new metadata/chapters once jobs complete.
+      void queryClient.invalidateQueries({ queryKey: ['series', 'detail', id] });
+      void queryClient.invalidateQueries({ queryKey: ['series', 'library'] });
+    },
+  });
+};
+
+/**
+ * Hook to rename a series folder + its .cbz archives to the canonical naming scheme.
+ */
+export const useRenameSeries = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<SeriesRenameResult, Error, string>({
+    mutationFn: (id: string) => seriesService.renameSeries(id),
+    onSuccess: (_, id) => {
+      // Storage path / filenames changed — refetch the detail (and library counts).
       void queryClient.invalidateQueries({ queryKey: ['series', 'detail', id] });
       void queryClient.invalidateQueries({ queryKey: ['series', 'library'] });
     },

--- a/RensaioFrontend/src/lib/api/services/seriesService.ts
+++ b/RensaioFrontend/src/lib/api/services/seriesService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/lib/api/client';
-import { type FullSeries, type SeriesInfo, type SeriesExtendedInfo, type ProviderMatch, type AugmentedResponse, type LatestSeriesInfo, type LatestGenre, type SearchSource, type SeriesIntegrityResult, type ChapterDetail } from '@/lib/api/types';
+import { type FullSeries, type SeriesInfo, type SeriesExtendedInfo, type ProviderMatch, type AugmentedResponse, type LatestSeriesInfo, type LatestGenre, type SearchSource, type SeriesIntegrityResult, type SeriesRenameResult, type ChapterDetail } from '@/lib/api/types';
 
 export const seriesService = {
   /**
@@ -127,6 +127,15 @@ export const seriesService = {
    */
   async updateAllSeries(): Promise<void> {
     return apiClient.post<void>('/api/serie/update-all', {});
+  },
+
+  /**
+   * Rename a single series folder to match its title and rename every downloaded
+   * .cbz to the canonical naming scheme. Fixes archives saved under an out-of-date name.
+   */
+  async renameSeries(id: string): Promise<SeriesRenameResult> {
+    const params = new URLSearchParams({ id });
+    return apiClient.post<SeriesRenameResult>(`/api/serie/rename?${params.toString()}`, {});
   },
 
   /**

--- a/RensaioFrontend/src/lib/api/types.ts
+++ b/RensaioFrontend/src/lib/api/types.ts
@@ -664,6 +664,22 @@ export interface SeriesIntegrityResult {
   badFiles: ArchiveIntegrityResult[];
 }
 
+export interface SeriesRenameResult {
+  success: boolean;
+  /** True when the series folder was renamed on disk. */
+  folderRenamed: boolean;
+  /** Relative storage path before the rename. */
+  oldFolder: string;
+  /** Relative storage path after the rename (unchanged if the folder was not renamed). */
+  newFolder: string;
+  /** Number of .cbz archives renamed to the canonical scheme. */
+  filesRenamed: number;
+  /** Number of archives that could not be renamed (e.g. target name already taken). */
+  filesFailed: number;
+  /** Optional human-readable note (e.g. why the folder rename was skipped). */
+  message?: string;
+}
+
 // --- User Management Types ---
 
 export interface User {


### PR DESCRIPTION
Adds a **Rename** action to the series page that renames the series folder and all owned `.cbz` archives to the canonical series title, plus naming fixes so new downloads follow the same convention.

## What's included
- New `POST /api/serie/rename` endpoint and `SeriesArchiveService.RenameSeriesAsync`: renames each owned archive to the `[Provider][lang] Title NNNN` scheme, renames the series folder leaf to the title, re-syncs `rensaio.json`, and reports renamed/skipped/failed counts.
- Reliable ownership detection via a new `ArchiveHelperService.MakeFileNamePrefixSafe` that reuses `MakeFileNameSafe`'s normalization instead of guessing at prefixes.
- Downloads are now named with the canonical series title (`ch.Title`) rather than the per-source title, and `UpdateProviderSettings` enforces that at most one source is flagged as title/cover.
- **Fixes the refresh-time title clobber the above depends on:** `GetChaptersAsync` unconditionally overwrote the canonical `SeriesEntity.Title` with the currently-refreshed provider's own title, ignoring the `IsTitle` flag — so downloads (and ComicInfo `<Series>`) were named after whichever provider refreshed last. The canonical title is now only updated by the provider flagged as the title source (or by any provider when none is flagged, preserving current behavior). The `CreateComicInfo(SeriesEntity, SeriesProviderEntity, ...)` overload's inverted `Series`/`LocalizedSeries` mapping is aligned with the download overload as part of this.
- Edge-case hardening: case-only renames work on case-insensitive filesystems (two-step move), a failed folder rename rolls back instead of stranding a temp folder, and prefix matching collapses whitespace consistently.
- UI: Rename button with confirmation dialog on the series page, and a failure toast when saving series settings fails.

## Testing
- Rebased onto current `main` (61b20fc); resolved the download-naming change against the refactored `DownloadCommandService` — all of the refactor is kept, only the title source changes.
- Backend builds with 0 errors; `RensaioFrontend` `pnpm build` passes.
- The feature was developed and exercised against a live library on our fork before rebasing. The refresh-time clobber was diagnosed from a production instance (see PR comment for the evidence trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
