### PR TITLE
fix(add-series): keep the modal in the viewport and stop scroll bleeding to the page

### DIFF
--- a/RensaioFrontend/src/components/comp/layout/page-layout.tsx
+++ b/RensaioFrontend/src/components/comp/layout/page-layout.tsx
@@ -39,7 +39,7 @@ export function PageLayout({
         <div className="flex h-dvh w-full flex-col bg-muted/40 overflow-hidden">
           <CommandBar />
           <main
-            className={`flex-1 min-h-0 overscroll-contain ${mainClassName}`}
+            className={`page-shell-main flex-1 min-h-0 overscroll-contain ${mainClassName}`}
           >
             {children}
           </main>

--- a/RensaioFrontend/src/components/comp/series/add-series/index.tsx
+++ b/RensaioFrontend/src/components/comp/series/add-series/index.tsx
@@ -74,7 +74,7 @@ export function AddSeries({
         {triggerElement}
       </DialogTrigger>
       <DialogContent
-        className="bg-transparent border-0 shadow-none p-0 max-h-none overflow-visible w-[calc(100vw-24px)] sm:w-[min(980px,calc(100vw-48px))] max-w-none top-[8vh] sm:top-[10vh] translate-y-0 [&>button]:hidden"
+        className="bg-transparent border-0 shadow-none p-0 max-h-none overflow-visible w-[calc(100vw-24px)] sm:w-[min(980px,calc(100vw-48px))] max-w-none top-[8dvh] sm:top-[10dvh] translate-y-0 [&>button]:hidden"
         onInteractOutside={(e) => {
           // Allow tap-outside dismiss on mobile; prevent on desktop
           if (!window.matchMedia("(max-width: 640px)").matches) {

--- a/RensaioFrontend/src/styles/globals.css
+++ b/RensaioFrontend/src/styles/globals.css
@@ -566,7 +566,8 @@
   overflow: hidden;
   position: relative;
   padding: 20px 24px;
-  max-height: 84vh;
+  max-height: 84vh; /* fallback for browsers without dvh support */
+  max-height: 84dvh; /* track the visible viewport so mobile browser toolbars can't push the modal off-screen */
   display: flex;
   flex-direction: column;
 }
@@ -695,6 +696,7 @@
 .res-list {
   padding: 6px 0 96px 0; /* extra bottom so last row clears the sticky CTA */
   overflow-y: auto;
+  overscroll-behavior: contain; /* stop touch scroll from chaining to the page behind the modal */
   flex: 1 1 auto;
   min-height: 0;
 }
@@ -711,6 +713,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain; /* stop touch scroll from chaining to the page behind the modal */
   padding-bottom: 96px; /* clearance for sticky CTA */
 }
 .confirm-scroll::-webkit-scrollbar {

--- a/RensaioFrontend/src/styles/globals.css
+++ b/RensaioFrontend/src/styles/globals.css
@@ -552,9 +552,18 @@
   flex-direction: column;
 }
 
+/* The app scrolls inside the page shell's <main>, not the body, so the body
+   scroll lock Radix applies while a dialog is open can't stop touch scrolling
+   from reaching the page behind the modal. react-remove-scroll flags the body
+   with data-scroll-locked whenever a modal is open — lock the shell's scroll
+   container for that duration too. */
+body[data-scroll-locked] .page-shell-main {
+  overflow: hidden !important;
+}
+
 /* The glass command card */
 .cmd-card {
-  background: hsla(240 10% 8% / 0.72);
+  background: hsla(240 10% 8% / 0.9);
   backdrop-filter: blur(28px) saturate(160%);
   -webkit-backdrop-filter: blur(28px) saturate(160%);
   border: 1px solid hsla(var(--as-border-strong));


### PR DESCRIPTION
Two small mobile/UX fixes for the add-series modal.

## What's included
- Use `dvh`-based top offset and max-height so the modal stays fully within the viewport on mobile browsers with dynamic toolbars.
- `overscroll-behavior: contain` on the modal's scrollable lists so reaching the end of a list no longer scrolls the page behind it.
- While a dialog is open, the page content behind it is locked (`overflow: hidden` on the page shell) so touch scrolling can't move the background; the glass card background is also more opaque (0.72 → 0.9) for readability.

## Testing
- Rebased onto current `main` (61b20fc); `RensaioFrontend` `pnpm build` passes.
- Behavior verified on our fork on mobile viewports before rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
