### PR TITLE
fix(dex2jar): 1.6 extension instancing — retype NEWs mistranslated on R8 stripped-constructor pattern

### DIFF
--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/Dex2JarConverter.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/Dex2JarConverter.cs
@@ -4,6 +4,7 @@ using com.googlecode.dex2jar.tools;
 using java.nio.file;
 using Microsoft.Extensions.Logging;
 using org.objectweb.asm;
+using org.objectweb.asm.tree;
 using System.IO.Compression;
 using System.Linq;
 using Mihon.ExtensionsBridge.Core.Extensions;
@@ -44,7 +45,13 @@ namespace Mihon.ExtensionsBridge.Core.Services
         /// <summary>
         /// Current converter version used to tag conversion results.
         /// </summary>
-        public const string Version = "1.0.0";
+        /// <remarks>
+        /// Bumped to 1.1.0 for the oracle-driven correction of dex2jar's R8 stripped-constructor
+        /// mistranslation (<see cref="DexNewInstanceCorrector"/>). Extensions previously converted with an
+        /// earlier version are re-converted on startup via <c>ExtensionManager.ValidateAndRecompileAsync</c>,
+        /// which compares <c>entry.Jar.Version</c> against this value.
+        /// </remarks>
+        public const string Version = "1.1.0";
 
         /// <summary>
         /// Classpath prefix used to redirect certain Android framework classes to compatibility replacements.
@@ -137,7 +144,10 @@ namespace Mihon.ExtensionsBridge.Core.Services
                 {
                     return false;
                 }
-                FixAndroidClasses(jarFilePath);
+                // Build the authoritative new-instance oracle from the same APK bytes (not a re-read),
+                // then correct dex2jar's R8 stripped-constructor mistranslation on the converted classes.
+                var oracle = DexNewInstanceOracle.Build(data);
+                FixAndroidClasses(jarFilePath, oracle);
                 ExtractAssetsFromApk(apkFile, jarFile);
                 return true;
             }, token).ConfigureAwait(false);
@@ -156,7 +166,11 @@ namespace Mihon.ExtensionsBridge.Core.Services
         /// to replace Android classes with compatibility implementations.
         /// </summary>
         /// <param name="jarFile">The path to the generated JAR file.</param>
-        public void FixAndroidClasses(java.nio.file.Path jarFile)
+        /// <param name="oracle">
+        /// The authoritative DEX <c>new-instance</c> oracle used to correct dex2jar's R8 stripped-constructor
+        /// mistranslation. All classes are collected first so cross-class constructor synthesis can run.
+        /// </param>
+        internal void FixAndroidClasses(java.nio.file.Path jarFile, DexNewInstanceOracle oracle)
         {
             FileSystem fs = null;
             try
@@ -165,38 +179,55 @@ namespace Mihon.ExtensionsBridge.Core.Services
 
                 var root = fs.getPath("/");
 
-                using var stream = Files.walk(root);
+                var entries = new List<(java.nio.file.Path path, ClassNode node)>();
 
-                var it = stream.iterator();
-                while (it.hasNext())
+                using (var stream = Files.walk(root))
                 {
-                    var p = (java.nio.file.Path)it.next();
-                    if (Files.isDirectory(p))
-                        continue;
-
-                    var pair = GetClassBytes(p);
-                    if (pair == null)
-                        continue;
-
-                    // Determine class name and delete entries that start with any of the remove namespaces
-                    var cr = new ClassReader(pair.Value.bytes);
-                    var className = cr.getClassName();
-                    if (ShouldRemoveNamespace(className))
+                    var it = stream.iterator();
+                    while (it.hasNext())
                     {
-                        try
-                        {
-                            _logger.LogDebug("Removing class due to namespace filter: {ClassName}", className);
-                            Files.delete(p);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to remove class {ClassName} at path {Path}", className, p.toString());
-                        }
-                        continue;
-                    }
+                        var p = (java.nio.file.Path)it.next();
+                        if (Files.isDirectory(p))
+                            continue;
 
-                    var transformed = Transform(pair.Value);
-                    Write(transformed);
+                        var pair = GetClassBytes(p);
+                        if (pair == null)
+                            continue;
+
+                        // Determine class name and delete entries that start with any of the remove namespaces
+                        var cr = new ClassReader(pair.Value.bytes);
+                        var className = cr.getClassName();
+                        if (ShouldRemoveNamespace(className))
+                        {
+                            try
+                            {
+                                _logger.LogDebug("Removing class due to namespace filter: {ClassName}", className);
+                                Files.delete(p);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, "Failed to remove class {ClassName} at path {Path}", className, p.toString());
+                            }
+                            continue;
+                        }
+
+                        // Apply the streaming replacements first, then parse into a tree node for correction.
+                        var transformed = Transform(pair.Value);
+                        var node = new ClassNode();
+                        new ClassReader(transformed.bytes).accept(node, 0);
+                        entries.Add((p, node));
+                    }
+                }
+
+                // Retype mistranslated NEWs across all classes and synthesise any missing default constructors.
+                var corrector = new DexNewInstanceCorrector(oracle, _logger);
+                corrector.CorrectAll(entries.Select(e => e.node).ToList());
+
+                // Write each corrected class back (frame hygiene + version lowering applied per class).
+                foreach (var entry in entries)
+                {
+                    var bytes = corrector.WriteClass(entry.node);
+                    Files.write(entry.path, bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
                 }
             }
             finally
@@ -408,19 +439,6 @@ namespace Mihon.ExtensionsBridge.Core.Services
             return _packagesToSkip.Any(prefix => className.StartsWith(prefix, StringComparison.Ordinal));
         }
 
-        /// <summary>
-        /// Writes transformed class bytes back into the JAR file system.
-        /// </summary>
-        /// <param name="pair">The path and transformed bytes to write.</param>
-        private void Write((java.nio.file.Path path, byte[] bytes) pair)
-        {
-            Files.write(
-                pair.path,
-                pair.bytes,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING
-            );
-        }
 
         /// <summary>
         /// Replaces a direct internal type name with its compatibility counterpart if listed.

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/DexNewInstanceCorrector.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/DexNewInstanceCorrector.cs
@@ -1,0 +1,406 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using org.objectweb.asm;
+using org.objectweb.asm.tree;
+using org.objectweb.asm.tree.analysis;
+
+namespace Mihon.ExtensionsBridge.Core.Services
+{
+    /// <summary>
+    /// Authoritative oracle of the <c>new-instance</c> type operands present in an APK's DEX, keyed by
+    /// <c>(className, methodName, methodDescriptor)</c> and ordered by their appearance in method code.
+    /// </summary>
+    /// <remarks>
+    /// dex2jar mistranslates R8's stripped-constructor pattern
+    /// (<c>new-instance vX, LT;</c> followed by <c>invoke-direct {vX}, Lsuper;-&gt;&lt;init&gt;()V</c> when
+    /// <c>T</c>'s trivial <c>&lt;init&gt;</c> was removed) into <c>new java/lang/Object</c> +
+    /// <c>invokespecial Object.&lt;init&gt;</c>. The resulting <c>Object</c> instance stored into a typed field
+    /// is rejected by the verifier or fails at runtime. Recovering the real type <c>T</c> requires reading the
+    /// DEX directly; this oracle does so via dex2jar's own reader/visitor API (no external tooling).
+    /// </remarks>
+    internal sealed class DexNewInstanceOracle
+    {
+        // key = className '\0' methodName '\0' methodDescriptor  ->  ordered internal type names.
+        private readonly Dictionary<string, List<string>> _map = new(System.StringComparer.Ordinal);
+
+        /// <summary>
+        /// Builds the oracle directly from the APK bytes using dex2jar's <see cref="com.googlecode.d2j.reader.MultiDexFileReader"/>
+        /// and a <see cref="com.googlecode.d2j.visitors.DexFileVisitor"/> chain that records <c>NEW_INSTANCE</c> operands.
+        /// </summary>
+        /// <param name="apkBytes">The raw APK bytes (the same buffer already read for conversion).</param>
+        /// <returns>A populated oracle.</returns>
+        public static DexNewInstanceOracle Build(byte[] apkBytes)
+        {
+            var oracle = new DexNewInstanceOracle();
+            var reader = com.googlecode.d2j.reader.MultiDexFileReader.open(apkBytes);
+            reader.accept(new FileVisitor(oracle));
+            return oracle;
+        }
+
+        /// <summary>
+        /// Returns the ordered list of <c>new-instance</c> internal type names for the given method, or <c>null</c>.
+        /// </summary>
+        public List<string>? Get(string className, string methodName, string methodDesc)
+            => _map.TryGetValue(Key(className, methodName, methodDesc), out var list) ? list : null;
+
+        private void Record(string className, string methodName, string methodDesc, List<string> types)
+        {
+            var key = Key(className, methodName, methodDesc);
+            // First occurrence wins; a well-formed extension APK defines each method once.
+            if (!_map.ContainsKey(key))
+                _map[key] = types;
+        }
+
+        private static string Key(string className, string methodName, string methodDesc)
+            => className + "\0" + methodName + "\0" + methodDesc;
+
+        /// <summary>Strips a <c>L...;</c> object descriptor to its internal name; leaves anything else as-is.</summary>
+        private static string InternalName(string desc)
+            => (desc != null && desc.Length > 2 && desc[0] == 'L' && desc[desc.Length - 1] == ';')
+                ? desc.Substring(1, desc.Length - 2)
+                : desc;
+
+        private static string DescriptorOf(com.googlecode.d2j.Method method)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.Append('(');
+            var parameters = method.getParameterTypes();
+            if (parameters != null)
+                foreach (var p in parameters)
+                    sb.Append(p);
+            sb.Append(')');
+            sb.Append(method.getReturnType());
+            return sb.ToString();
+        }
+
+        private sealed class FileVisitor : com.googlecode.d2j.visitors.DexFileVisitor
+        {
+            private readonly DexNewInstanceOracle _oracle;
+            public FileVisitor(DexNewInstanceOracle oracle) => _oracle = oracle;
+
+            public override com.googlecode.d2j.visitors.DexClassVisitor visit(
+                int access, string className, string superClass, string[] interfaces)
+                => new ClassVisitor(_oracle, InternalName(className));
+        }
+
+        private sealed class ClassVisitor : com.googlecode.d2j.visitors.DexClassVisitor
+        {
+            private readonly DexNewInstanceOracle _oracle;
+            private readonly string _className;
+            public ClassVisitor(DexNewInstanceOracle oracle, string className)
+            {
+                _oracle = oracle;
+                _className = className;
+            }
+
+            public override com.googlecode.d2j.visitors.DexMethodVisitor visitMethod(
+                int access, com.googlecode.d2j.Method method)
+                => new MethodVisitor(_oracle, _className, method.getName(), DescriptorOf(method));
+        }
+
+        private sealed class MethodVisitor : com.googlecode.d2j.visitors.DexMethodVisitor
+        {
+            private readonly DexNewInstanceOracle _oracle;
+            private readonly string _className;
+            private readonly string _methodName;
+            private readonly string _methodDesc;
+            public MethodVisitor(DexNewInstanceOracle oracle, string className, string methodName, string methodDesc)
+            {
+                _oracle = oracle;
+                _className = className;
+                _methodName = methodName;
+                _methodDesc = methodDesc;
+            }
+
+            public override com.googlecode.d2j.visitors.DexCodeVisitor visitCode()
+                => new CodeVisitor(_oracle, _className, _methodName, _methodDesc);
+        }
+
+        private sealed class CodeVisitor : com.googlecode.d2j.visitors.DexCodeVisitor
+        {
+            private readonly DexNewInstanceOracle _oracle;
+            private readonly string _className;
+            private readonly string _methodName;
+            private readonly string _methodDesc;
+            private readonly List<string> _types = new();
+            public CodeVisitor(DexNewInstanceOracle oracle, string className, string methodName, string methodDesc)
+            {
+                _oracle = oracle;
+                _className = className;
+                _methodName = methodName;
+                _methodDesc = methodDesc;
+            }
+
+            public override void visitTypeStmt(com.googlecode.d2j.reader.Op op, int a, int b, string type)
+            {
+                // visitTypeStmt is also used for CHECK_CAST / INSTANCE_OF / NEW_ARRAY; only NEW_INSTANCE allocates.
+                if (ReferenceEquals(op, com.googlecode.d2j.reader.Op.NEW_INSTANCE))
+                    _types.Add(InternalName(type));
+            }
+
+            public override void visitEnd()
+                => _oracle.Record(_className, _methodName, _methodDesc, _types);
+        }
+    }
+
+    /// <summary>
+    /// Applies the oracle-driven correction of dex2jar's <c>NEW java/lang/Object</c> mistranslation across a set of
+    /// converted classes, synthesises missing default constructors on the recovered target types, and lowers the
+    /// class-file version while stripping <c>StackMapTable</c> frames so downstream inference verifiers accept the
+    /// now type-correct code. Ported from the validated <c>FixInit2</c> reference.
+    /// </summary>
+    internal sealed class DexNewInstanceCorrector
+    {
+        private readonly DexNewInstanceOracle _oracle;
+        private readonly ILogger _logger;
+
+        /// <summary>Java class-file major version 49 (Java 5) — forces HotSpot's type-inference verifier.</summary>
+        private const int TargetMajorVersion = 49;
+
+        public DexNewInstanceCorrector(DexNewInstanceOracle oracle, ILogger logger)
+        {
+            _oracle = oracle;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retypes mistranslated <c>NEW</c> instructions across all supplied classes and synthesises any missing
+        /// default constructors on the recovered target types.
+        /// </summary>
+        /// <param name="nodes">All converted classes in the JAR, as ASM tree nodes.</param>
+        public void CorrectAll(IReadOnlyList<ClassNode> nodes)
+        {
+            var byName = new Dictionary<string, ClassNode>(System.StringComparer.Ordinal);
+            foreach (var cn in nodes)
+                byName[cn.name] = cn;
+
+            var ctorNeeded = new HashSet<string>(System.StringComparer.Ordinal);
+            int retyped = 0, skippedMethods = 0;
+
+            foreach (var cn in nodes)
+            {
+                for (int i = 0; i < cn.methods.size(); i++)
+                {
+                    var mn = (MethodNode)cn.methods.get(i);
+                    if (mn.instructions.size() == 0)
+                        continue;
+                    try
+                    {
+                        var result = FixMethod(cn, mn, ctorNeeded);
+                        retyped += result.retyped;
+                        skippedMethods += result.skipped;
+                    }
+                    catch (System.Exception ex)
+                    {
+                        // Safe fallback: never let one method abort the conversion.
+                        skippedMethods++;
+                        _logger.LogTrace(ex, "DexNewInstanceCorrector: skipped method {Class}.{Method}{Desc}", cn.name, mn.name, mn.desc);
+                    }
+                }
+            }
+
+            int synth = SynthesizeConstructors(byName, ctorNeeded);
+
+            if (retyped > 0 || synth > 0)
+                _logger.LogDebug(
+                    "DexNewInstanceCorrector: retypedNew={Retyped} synthCtors={Synth} skippedMethods={Skipped}",
+                    retyped, synth, skippedMethods);
+        }
+
+        /// <summary>
+        /// Serialises a corrected class: for non-<c>invokedynamic</c> classes it strips <c>StackMapTable</c> frames and
+        /// lowers the version to 49; classes containing <c>invokedynamic</c> keep their version and frames untouched.
+        /// </summary>
+        public byte[] WriteClass(ClassNode cn)
+        {
+            if (!HasInvokeDynamic(cn))
+            {
+                StripFrames(cn);
+                cn.version = TargetMajorVersion;
+            }
+
+            // COMPUTE_MAXS: dex2jar's declared max_stack is frequently too small for HotSpot's v49
+            // type-inference verifier ("Stack size too large"), so recompute it. COMPUTE_MAXS is a purely
+            // local pass (no classpath needed) and never rewrites StackMapTable frames, so the invokedynamic
+            // classes that retain their frames above are unaffected. Matches the validated FixInit2 reference.
+            var cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            cn.accept(cw);
+            return cw.toByteArray();
+        }
+
+        private (int retyped, int skipped) FixMethod(ClassNode cn, MethodNode mn, HashSet<string> ctorNeeded)
+        {
+            // Ordered JVM NEW instructions.
+            var jvmNews = new List<TypeInsnNode>();
+            for (AbstractInsnNode p = mn.instructions.getFirst(); p != null; p = p.getNext())
+                if (p.getOpcode() == Opcodes.NEW)
+                    jvmNews.Add((TypeInsnNode)p);
+            if (jvmNews.Count == 0)
+                return (0, 0);
+
+            if (!jvmNews.Any(t => t.desc == "java/lang/Object"))
+                return (0, 0);
+
+            var dex = _oracle.Get(cn.name, mn.name, mn.desc);
+            if (dex == null || dex.Count != jvmNews.Count)
+                return (0, 1); // guard: counts disagree -> leave method untouched
+
+            // Residual matching: remove concrete (non-Object) JVM types from a copy of the DEX list (order-preserving
+            // multiset), then assign the leftover DEX types, in order, to the Object-typed NEWs, in order.
+            var residual = new List<string>(dex);
+            foreach (var t in jvmNews)
+                if (t.desc != "java/lang/Object")
+                    residual.Remove(t.desc);
+
+            var newToType = new Dictionary<TypeInsnNode, string>(ReferenceEqualityComparer.Instance);
+            int ri = 0;
+            foreach (var t in jvmNews)
+            {
+                if (t.desc != "java/lang/Object")
+                    continue;
+                if (ri >= residual.Count)
+                    break;
+                string target = residual[ri++];
+                if (target == "java/lang/Object")
+                    continue; // genuine new Object
+                newToType[t] = target;
+            }
+            if (newToType.Count == 0)
+                return (0, 0);
+
+            // Pair each retyped NEW with its <init> invokespecial through origin tracking.
+            Frame[] frames;
+            try
+            {
+                var analyzer = new Analyzer(new OriginInterpreter());
+                frames = analyzer.analyze(cn.name, mn);
+            }
+            catch (AnalyzerException)
+            {
+                return (0, 1);
+            }
+
+            var insns = mn.instructions.toArray();
+            for (int i = 0; i < insns.Length; i++)
+            {
+                if (insns[i].getOpcode() != Opcodes.INVOKESPECIAL)
+                    continue;
+                var min = (MethodInsnNode)insns[i];
+                if (min.name != "<init>")
+                    continue;
+                var fr = frames[i];
+                if (fr == null)
+                    continue;
+
+                int argSize = org.objectweb.asm.Type.getArgumentTypes(min.desc).Length;
+                int recvIndex = fr.getStackSize() - 1 - argSize;
+                if (recvIndex < 0)
+                    continue;
+                var recv = (SourceValue)fr.getStack(recvIndex);
+                foreach (var src in IterateInsns(recv.insns))
+                {
+                    if (src is TypeInsnNode tin && newToType.TryGetValue(tin, out var target))
+                    {
+                        // Only the mistranslated ()V pattern is safe to rewrite; leave any non-()V ctor alone.
+                        if (min.desc == "()V")
+                        {
+                            min.owner = target;
+                            ctorNeeded.Add(target);
+                        }
+                    }
+                }
+            }
+
+            int n = 0;
+            foreach (var kv in newToType)
+            {
+                kv.Key.desc = kv.Value;
+                n++;
+            }
+            return (n, 0);
+        }
+
+        private int SynthesizeConstructors(Dictionary<string, ClassNode> byName, HashSet<string> ctorNeeded)
+        {
+            int synth = 0;
+            foreach (var target in ctorNeeded)
+            {
+                if (!byName.TryGetValue(target, out var cn))
+                    continue; // target lives in a library, not this JAR
+
+                bool has = false;
+                for (int i = 0; i < cn.methods.size(); i++)
+                {
+                    var m = (MethodNode)cn.methods.get(i);
+                    if (m.name == "<init>" && m.desc == "()V")
+                    {
+                        has = true;
+                        break;
+                    }
+                }
+                if (has)
+                    continue;
+
+                string sup = cn.superName ?? "java/lang/Object";
+                var ctor = new MethodNode(Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC, "<init>", "()V", (string?)null, (string[]?)null);
+                var il = ctor.instructions;
+                il.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                il.add(new MethodInsnNode(Opcodes.INVOKESPECIAL, sup, "<init>", "()V", false));
+                il.add(new InsnNode(Opcodes.RETURN));
+                ctor.maxStack = 1;
+                ctor.maxLocals = 1;
+                cn.methods.add(ctor);
+                synth++;
+            }
+            return synth;
+        }
+
+        private static void StripFrames(ClassNode cn)
+        {
+            for (int i = 0; i < cn.methods.size(); i++)
+            {
+                var mn = (MethodNode)cn.methods.get(i);
+                for (AbstractInsnNode p = mn.instructions.getFirst(); p != null;)
+                {
+                    AbstractInsnNode next = p.getNext();
+                    if (p is FrameNode)
+                        mn.instructions.remove(p);
+                    p = next;
+                }
+            }
+        }
+
+        private static bool HasInvokeDynamic(ClassNode cn)
+        {
+            for (int i = 0; i < cn.methods.size(); i++)
+            {
+                var mn = (MethodNode)cn.methods.get(i);
+                for (AbstractInsnNode p = mn.instructions.getFirst(); p != null; p = p.getNext())
+                    if (p.getOpcode() == Opcodes.INVOKEDYNAMIC)
+                        return true;
+            }
+            return false;
+        }
+
+        private static IEnumerable<AbstractInsnNode> IterateInsns(java.util.Set set)
+        {
+            if (set == null)
+                yield break;
+            var it = set.iterator();
+            while (it.hasNext())
+                yield return (AbstractInsnNode)it.next();
+        }
+
+        /// <summary>
+        /// <see cref="SourceInterpreter"/> that preserves value origin through copy operations (dup/load/store),
+        /// so a stack value can be traced back to the <c>NEW</c> that produced it even across local slots.
+        /// </summary>
+        private sealed class OriginInterpreter : SourceInterpreter
+        {
+            public OriginInterpreter() : base(Opcodes.ASM9) { }
+
+            public override SourceValue copyOperation(AbstractInsnNode insn, SourceValue value) => value;
+        }
+    }
+}


### PR DESCRIPTION
@maxpiva — this fixes the 1.6 instancing failures you reported (asurascans `VerifyError`, infernalvoidscans/HiveScans `InvocationTargetException`). Good news: **your Android compat layer is not missing anything.** We diffed it against Komikku's extensions-lib 1.6 surface (suspend API, related-manga members, `memo`, `getImageUrl`) and it is API-complete. The bug is in **dex2jar itself**, and the new keiyoushi 1.6 toolchain's R8 output triggers it heavily — which is why 1.4-era APKs were fine and Suwayomi would indeed also fail.

## Root cause

When R8 strips a class `T`'s trivial constructor, the DEX contains:

```
new-instance vX, LT;
invoke-direct {vX}, Lsuper;-><init>()V   // T's <init> was removed by R8
```

dex2jar (all versions 2.4.5–2.4.37, every flag combination) derives the JVM `NEW` type from the **invoke-direct owner** instead of the **new-instance operand**, emitting `new java/lang/Object` + `invokespecial Object.<init>` where `new T` was intended. The resulting `Object` stored into a `T`-typed field is rejected even by IKVM's lenient verifier (asurascans, 51 failing classes) or survives loading and dies at runtime (infernalvoidscans, ICCE `Object does not implement Function1` inside a lazy initializer — 40 failing classes). dex2jar additionally emits broken StackMapTable frames, which is why HotSpot and IKVM show different symptoms for the same jars.

## Fix

`DexNewInstanceCorrector` runs after conversion inside `Dex2JarConverter`:

- Builds an oracle of the true `new-instance` types straight from the APK's DEX, using dex2jar's own `MultiDexFileReader` (no new dependencies).
- Per method, retypes the mistranslated `Object`-typed `NEW`s (order-preserving residual matching; the paired `<init>` invokespecial is traced through an ASM `SourceInterpreter`, so dup/store/load chains are handled) and synthesizes the R8-stripped no-arg constructors.
- Strips StackMapTable frames and lowers non-invokedynamic classes to v49 so inference verifiers accept them; `ClassWriter(COMPUTE_MAXS)` recomputes dex2jar's occasionally-undersized max_stack.
- Heavily guarded: any DEX/JVM count mismatch or analysis failure leaves the method untouched, so it can never make a jar worse.

`Dex2JarConverter.Version` is bumped to 1.1.0, so all previously converted jars reconvert automatically at next startup — no user action needed.

## Validation (HotSpot harness, compat fat jar on parent classpath)

| APK | VerifyErrors before → after | Instancing |
|---|---|---|
| tachiyomi-en.asurascans-v1.6.66 | 51 → **0** | reaches Koin bootstrap (success outside the app; the app starts Koin in `applicationSetup`) |
| tachiyomi-en.infernalvoidscans-v1.6.66 | 40 → **0** | **full instantiation: "Hive Scans (EN)"** |
| mangadex (regression) | 80 → 13 | residuals pre-exist the fix, IKVM-tolerated |
| nhentai (regression) | 27 → 1 | same |
| asurascanstr 1.4.52 (control) | 16 → 3 | corrector correctly no-ops on old-toolchain output |

Every post-fix failing set is a strict subset of its baseline — the pass never introduces a new failure. The remaining residuals are distinct, pre-existing dex2jar defects ("Call to wrong initialization method", "Bad access to protected data") that IKVM already tolerates today.

Worth noting upstream: the actual dex2jar bug is one line of intent — derive the `NEW` type from the `new-instance` operand rather than the `invoke-direct` owner. Happy to file it against dex2jar if useful.
