### PR TITLE
Fix OPDS panels not loading: bad images, format conversion 404s, and extraction races

### DIFF
--- a/RensaioBackend/Services/Opds/OpdsExtractionCoordinator.cs
+++ b/RensaioBackend/Services/Opds/OpdsExtractionCoordinator.cs
@@ -49,33 +49,28 @@ public class OpdsExtractionCoordinator
     // ──────────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Cancels the active extraction (if any) for the given user and deletes
-    /// the partial cache directory so a fresh extraction can start cleanly.
+    /// Cancels the active extraction (if any) for the given user.
+    /// The partial cache directory is intentionally kept: extracted pages are
+    /// written atomically, so a later extraction of the same chapter resumes
+    /// from them instead of re-extracting (deleting here also fails on Windows
+    /// while a page file is open, stranding a half-deleted directory).
+    /// The extraction task owns and disposes its own CancellationTokenSource.
     /// </summary>
     public void CancelActiveExtraction(string userKey)
     {
         if (_activeUserExtractions.TryRemove(userKey, out var state))
         {
-            if (!state.Cts.IsCancellationRequested)
+            try
             {
-                state.Cts.Cancel();
+                if (!state.Cts.IsCancellationRequested)
+                {
+                    state.Cts.Cancel();
+                }
             }
-
-            // Delete partial cache directory (if it was being extracted)
-            if (!string.IsNullOrEmpty(state.CacheDir) && Directory.Exists(state.CacheDir))
+            catch (ObjectDisposedException)
             {
-                DeleteCacheDirectory(state.CacheDir);
+                // Extraction already finished and disposed its CTS
             }
-
-            // Wait briefly for the task to finish cleanup, but don't block long
-            if (state.ExtractionTask != null)
-            {
-                try { state.ExtractionTask.GetAwaiter().GetResult(); }
-                catch (OperationCanceledException) { }
-                catch { /* swallow */ }
-            }
-
-            state.Cts.Dispose();
         }
     }
 
@@ -146,16 +141,30 @@ public class OpdsExtractionCoordinator
     public static string GetUserKey(string username) => username;
 
     /// <summary>
-    /// Deletes a cache directory recursively, best-effort.
+    /// Marker file written after a chapter finishes extracting with no failed pages.
+    /// A cache directory without this marker is partial (canceled/failed/legacy)
+    /// and must not be trusted for index-based page lookups.
     /// </summary>
-    public static void DeleteCacheDirectory(string cacheDir)
+    public const string CompleteMarkerFileName = ".complete";
+
+    /// <summary>
+    /// True if the chapter cache directory was fully extracted.
+    /// </summary>
+    public static bool IsChapterCacheComplete(string cacheDir)
+    {
+        return File.Exists(Path.Combine(cacheDir, CompleteMarkerFileName));
+    }
+
+    /// <summary>
+    /// Marks a chapter cache directory as fully extracted, best-effort.
+    /// </summary>
+    public static void MarkChapterCacheComplete(string cacheDir)
     {
         try
         {
-            if (Directory.Exists(cacheDir))
-                Directory.Delete(cacheDir, true);
+            File.WriteAllText(Path.Combine(cacheDir, CompleteMarkerFileName), "");
         }
-        catch { /* best effort */ }
+        catch { /* best effort — worst case the chapter re-extracts (and resumes) */ }
     }
 
     /// <summary>

--- a/RensaioBackend/Services/Opds/OpdsImageService.cs
+++ b/RensaioBackend/Services/Opds/OpdsImageService.cs
@@ -100,56 +100,55 @@ public class OpdsImageService
             if (pageIndex < state.Pages.Count)
             {
                 string entryKey = state.Pages[pageIndex].Replace('/', System.IO.Path.DirectorySeparatorChar);
-                string pageFile = System.IO.Path.Combine(cacheDir, entryKey);
-                if (File.Exists(pageFile))
+                string? pageFile = ResolvePageFile(cacheDir, entryKey);
+                if (pageFile != null)
                 {
                     return await ReadAndConvertPageAsync(pageFile, supportedImageFormats, seriesStoragePath, chapterFilename, pageIndex, token);
                 }
             }
         }
-        else if (Directory.Exists(cacheDir))
+        else if (OpdsExtractionCoordinator.IsChapterCacheComplete(cacheDir))
         {
-            // Fallback: no active state, but cache dir exists — scan it directly
-            // Account for multiple extensions due to format conversions
+            // Fallback: no active state, but the chapter is fully cached — scan it directly.
+            // Partial directories (canceled/failed extraction) have no completion marker
+            // and fall through to extraction below, which resumes from existing files.
             return await ReadPageFromCacheDirAsync(cacheDir, pageIndex, supportedImageFormats, seriesStoragePath, chapterFilename, token);
         }
 
         // ── Ensure extraction is running for this chapter ──
-        // Use per-chapter lock to prevent multiple threads from starting extraction
-        // of the same chapter simultaneously (double-checked locking pattern).
-        //
-        // The lock is only held during the decision to start extraction, not during
-        // extraction itself (which runs as a fire-and-forget background task).
-        // After acquiring the lock, we double-check the cache and extraction state
-        // in case another thread completed extraction while we waited.
-        using (await _coordinator.AcquireChapterLockAsync(cacheKey, token))
+        // If there's no active extraction for this exact chapter, cancel any other
+        // extraction for this user and start one for the requested chapter.
+        // Serialized per chapter so parallel page requests from a reader don't
+        // each cancel the others' just-started extraction.
+        if (!_coordinator.TryGetExtraction(userKey, out state) ||
+            state.ChapterCacheKey != cacheKey ||
+            state.ExtractionTask is { IsCompleted: true })
         {
-            // Double-check: another thread may have completed extraction while we waited
-            // for the lock. If the cache directory exists with files, try reading from it.
-            if (Directory.Exists(cacheDir))
+            using (await _coordinator.AcquireChapterLockAsync(cacheKey, token))
             {
-                var result = await ReadPageFromCacheDirAsync(cacheDir, pageIndex, supportedImageFormats,
-                    seriesStoragePath, chapterFilename, token);
-                if (result.imageStream != null)
-                    return result;
+                // Double-check under the lock: another request may have fully extracted
+                // the chapter (completion marker written) while we waited.
+                if (OpdsExtractionCoordinator.IsChapterCacheComplete(cacheDir))
+                {
+                    return await ReadPageFromCacheDirAsync(cacheDir, pageIndex, supportedImageFormats, seriesStoragePath, chapterFilename, token);
+                }
+
+                // Re-check the extraction state — a concurrent request may have started it
+                if (!_coordinator.TryGetExtraction(userKey, out state) ||
+                    state.ChapterCacheKey != cacheKey ||
+                    state.ExtractionTask is { IsCompleted: true })
+                {
+                    _coordinator.CancelActiveExtraction(userKey);
+
+                    // Setup extraction (DB lookup, pages, signals) and fire the task without awaiting it.
+                    // The state is stored in the coordinator so we can wait for the page signal.
+                    state = await SetupAndFireExtractionAsync(
+                        userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
+                }
             }
 
-            // If there's no active extraction for this exact chapter, cancel any other
-            // extraction for this user and start one for the requested chapter.
-            if (!_coordinator.TryGetExtraction(userKey, out state) ||
-                state.ChapterCacheKey != cacheKey ||
-                state.ExtractionTask is { IsCompleted: true })
-            {
-                _coordinator.CancelActiveExtraction(userKey);
-
-                // Setup extraction (DB lookup, pages, signals) and fire the task without awaiting it.
-                // The state is stored in the coordinator so we can wait for the page signal.
-                state = await SetupAndFireExtractionAsync(
-                    userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
-
-                if (state == null)
-                    return (null, null, null);
-            }
+            if (state == null)
+                return (null, null, null);
         }
 
         // ── Wait for the specific page to be extracted ──
@@ -171,9 +170,11 @@ public class OpdsImageService
                     return (null, null, null);
                 }
 
-                // Read the file now that it's ready — run conversion if needed
-                string pageFile = System.IO.Path.Combine(cacheDir, entryKey);
-                if (File.Exists(pageFile))
+                // Read the file now that it's ready — run conversion if needed.
+                // The extracted file may have a different extension than the archive
+                // entry: format conversion replaces the original (e.g. .webp → .jpg).
+                string? pageFile = ResolvePageFile(cacheDir, entryKey);
+                if (pageFile != null)
                 {
                     return await ReadAndConvertPageAsync(pageFile, supportedImageFormats, seriesStoragePath, chapterFilename, pageIndex, token);
                 }
@@ -247,6 +248,9 @@ public class OpdsImageService
         string cacheKey = $"{seriesId}:{language}:{chapterFilename}";
         string cacheDir = GetCacheDirectory(seriesId, language, chapterFilename);
 
+        // Already fully cached – nothing to do (a partial dir without the marker re-extracts and resumes)
+        if (OpdsExtractionCoordinator.IsChapterCacheComplete(cacheDir))
+            return Task.CompletedTask;
         // Resolve the full archive path before extraction
         string? archivePath = _settingsService.DirectSettings?.ResolveChapterPath(seriesStoragePath, chapterFilename);
         if (archivePath == null)
@@ -256,32 +260,19 @@ public class OpdsImageService
             return Task.CompletedTask;
         }
 
-        // Use per-chapter lock to prevent concurrent extraction of the same chapter.
-        // Double-check cache after acquiring the lock.
-        return EnsureChapterIsLoadedLockedAsync(userKey, cacheKey, cacheDir, seriesId, title, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
-    }
-
-    /// <summary>
-    /// Per-chapter-locked portion of <see cref="EnsureChapterIsLoadedAsync"/>.
-    /// Acquires the per-chapter semaphore, double-checks the cache, then starts extraction.
-    /// </summary>
-    private async Task EnsureChapterIsLoadedLockedAsync(
-        string userKey, string cacheKey, string cacheDir,
-        Guid seriesId, string title, string archivePath, string chapterFilename,
-        string seriesStoragePath, List<string> supportedImageFormats)
-    {
-        using (await _coordinator.AcquireChapterLockAsync(cacheKey, CancellationToken.None))
+        // This exact chapter is already being extracted – just wait for it
+        if (_coordinator.TryGetExtraction(userKey, out var active) &&
+            active.ChapterCacheKey == cacheKey &&
+            active.ExtractionTask is { IsCompleted: false } activeTask)
         {
-            // Double-check: another thread may have completed extraction while we waited
-            if (Directory.Exists(cacheDir) && Directory.GetFiles(cacheDir).Length > 0)
-                return;
-
-            // Cancel any existing preload for this user
-            _coordinator.CancelActiveExtraction(userKey);
-
-            // Start extraction with the full archive path
-            await StartExtractionAsync(userKey, seriesId, title, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
+            return activeTask;
         }
+
+        // Cancel any existing preload for this user
+        _coordinator.CancelActiveExtraction(userKey);
+
+        // Start extraction with the full archive path
+        return StartExtractionAsync(userKey, seriesId, title, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -357,8 +348,14 @@ public class OpdsImageService
             string cacheKey = $"{seriesId}:{lang}:{chapterFilename}";
             string cacheDir = GetCacheDirectory(seriesId, lang, chapterFilename);
 
-            // Already cached – nothing to do
-            if (Directory.Exists(cacheDir) && Directory.GetFiles(cacheDir).Length > 0)
+            // Already fully cached – nothing to do
+            if (OpdsExtractionCoordinator.IsChapterCacheComplete(cacheDir))
+                return;
+
+            // An extraction is already running for this user (likely the chapter
+            // they are reading right now) — a background preload must not steal it
+            if (_coordinator.TryGetExtraction(userKey, out var active) &&
+                active.ExtractionTask is { IsCompleted: false })
                 return;
 
             // Resolve the full archive path before extraction
@@ -370,8 +367,10 @@ public class OpdsImageService
                 return;
             }
 
-            // Use per-chapter lock to prevent concurrent extraction of the same chapter.
-            await PreloadChapterLockedAsync(userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
+            // Clear any completed extraction state for this user
+            _coordinator.CancelActiveExtraction(userKey);
+
+            await StartExtractionAsync(userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
         }
         catch (OperationCanceledException)
         {
@@ -445,8 +444,8 @@ public class OpdsImageService
             string cacheKey = $"{seriesId}:{lang}:{chapterFilename}";
             string cacheDir = GetCacheDirectory(seriesId, lang, chapterFilename);
 
-            // Already cached – nothing to do
-            if (Directory.Exists(cacheDir) && Directory.GetFiles(cacheDir).Length > 0)
+            // Already fully cached – nothing to do
+            if (OpdsExtractionCoordinator.IsChapterCacheComplete(cacheDir))
                 return;
 
             // Wait for any current extraction for this user to finish
@@ -467,8 +466,15 @@ public class OpdsImageService
                 return;
             }
 
-            // Use per-chapter lock to prevent concurrent extraction of the same chapter.
-            await PreloadChapterLockedAsync(userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
+            // If a new extraction started while we were waiting (the user began
+            // reading something), don't steal it for a background preload
+            if (_coordinator.TryGetExtraction(userKey, out var newActive) &&
+                newActive.ExtractionTask is { IsCompleted: false })
+                return;
+
+            // Start extraction of the next chapter
+            _coordinator.CancelActiveExtraction(userKey);
+            await StartExtractionAsync(userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
         }
         catch (OperationCanceledException)
         {
@@ -588,28 +594,6 @@ public class OpdsImageService
     }
 
     /// <summary>
-    /// Acquires a per-chapter lock, double-checks the cache, then starts extraction.
-    /// Used by preload methods to prevent concurrent extraction of the same chapter.
-    /// </summary>
-    private async Task PreloadChapterLockedAsync(
-        string userKey, Guid seriesId, string name, string cacheKey, string cacheDir,
-        string archivePath, string chapterFilename, string seriesStoragePath,
-        List<string> supportedImageFormats)
-    {
-        using (await _coordinator.AcquireChapterLockAsync(cacheKey, CancellationToken.None))
-        {
-            // Double-check: another thread may have completed extraction while we waited
-            if (Directory.Exists(cacheDir) && Directory.GetFiles(cacheDir).Length > 0)
-                return;
-
-            // Cancel any existing extraction for this user
-            _coordinator.CancelActiveExtraction(userKey);
-
-            await StartExtractionAsync(userKey, seriesId, name, cacheKey, cacheDir, archivePath, chapterFilename, seriesStoragePath, supportedImageFormats);
-        }
-    }
-
-    /// <summary>
     /// Extracts an archive entry-by-entry, signaling per-page TaskCompletionSource
     /// as each matching entry finishes writing to cache.
     /// After writing each entry, runs image format conversion if the client
@@ -626,8 +610,19 @@ public class OpdsImageService
         // Build a lookup set for faster matching
         var pageSet = new HashSet<string>(state.Pages, StringComparer.OrdinalIgnoreCase);
 
+        // Serialize extraction per chapter: two users (or a raced restart) targeting
+        // the same chapter share the cache directory, and concurrent writes to the
+        // same files cause sharing violations on Windows. The second extractor
+        // acquires the lock after the first finishes and cheaply skips existing files.
+        var chapterLock = _coordinator.GetChapterLock(state.ChapterCacheKey);
+        bool lockTaken = false;
+        bool anyPageFailed = false;
+
         try
         {
+            await chapterLock.WaitAsync(cts.Token);
+            lockTaken = true;
+
             var archive = await SharpCompress.Archives.ArchiveFactory.OpenAsyncArchive(archivePath);
             var allEntries = archive.EntriesAsync;
 
@@ -640,16 +635,58 @@ public class OpdsImageService
 
                 string entryKey = entry.Key?.Replace('/', System.IO.Path.DirectorySeparatorChar) ?? "";
                 string fullPath = System.IO.Path.Combine(cacheDir, entryKey);
+                bool isPage = pageSet.Contains(entryKey);
 
-                // Create subdirectories if needed
-                string? dir = System.IO.Path.GetDirectoryName(fullPath);
-                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                    Directory.CreateDirectory(dir);
+                // Resume support: skip entries already extracted (or extracted+converted)
+                // by a previous run of this chapter
+                if (ResolvePageFile(cacheDir, entryKey) != null)
+                {
+                    if (isPage && state.PageSignals.TryGetValue(entryKey, out var doneTcs))
+                        doneTcs.TrySetResult();
+                    continue;
+                }
 
-                await entry.WriteToFileAsync(fullPath, null, cts.Token);
+                try
+                {
+                    // Create subdirectories if needed
+                    string? dir = System.IO.Path.GetDirectoryName(fullPath);
+                    if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                        Directory.CreateDirectory(dir);
+
+                    // Write to a temp file and move into place so a cancel/crash
+                    // never leaves a truncated page behind for a later resume to trust
+                    string tempPath = fullPath + ".tmp";
+                    try
+                    {
+                        await entry.WriteToFileAsync(tempPath, null, cts.Token);
+                        File.Move(tempPath, fullPath, overwrite: true);
+                    }
+                    catch
+                    {
+                        try { File.Delete(tempPath); } catch { /* best effort */ }
+                        throw;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // One bad entry must not fail the rest of the chapter:
+                    // fail only this page's signal and keep extracting
+                    _logger.LogWarning(ex, "Failed to extract entry {EntryKey} from {ArchivePath}", entryKey, archivePath);
+                    if (isPage)
+                    {
+                        anyPageFailed = true;
+                        if (state.PageSignals.TryGetValue(entryKey, out var failedTcs))
+                            failedTcs.TrySetException(ex);
+                    }
+                    continue;
+                }
 
                 // Convert image format if needed and client has format preferences
-                if (state.SupportedImageFormats.Count > 0 && pageSet.Contains(entryKey))
+                if (state.SupportedImageFormats.Count > 0 && isPage)
                 {
                     try
                     {
@@ -667,8 +704,7 @@ public class OpdsImageService
                 }
 
                 // Signal this specific page if it's in our Pages list
-                if (pageSet.Contains(entryKey) &&
-                    state.PageSignals.TryGetValue(entryKey, out var tcs))
+                if (isPage && state.PageSignals.TryGetValue(entryKey, out var tcs))
                 {
                     tcs.TrySetResult();
                 }
@@ -677,45 +713,55 @@ public class OpdsImageService
             // After all entries processed, signal any remaining pages that weren't found
             foreach (var kvp in state.PageSignals)
             {
-                kvp.Value.TrySetException(new InvalidOperationException(
-                    $"Page entry '{kvp.Key}' was not found in the archive"));
+                if (kvp.Value.TrySetException(new InvalidOperationException(
+                        $"Page entry '{kvp.Key}' was not found in the archive")))
+                {
+                    anyPageFailed = true;
+                }
             }
 
             // Only manage cache if extraction completed successfully (not canceled)
             if (!cts.Token.IsCancellationRequested)
             {
+                if (!anyPageFailed)
+                    OpdsExtractionCoordinator.MarkChapterCacheComplete(cacheDir);
                 await ManageCacheSizeAsync();
             }
         }
         catch (OperationCanceledException)
         {
-            // On cancel, set all pending signals as canceled
+            // On cancel, set all pending signals as canceled.
+            // The partial cache is kept — files are written atomically, so a later
+            // extraction of this chapter resumes from them.
             foreach (var kvp in state.PageSignals)
             {
                 kvp.Value.TrySetCanceled(cts.Token);
             }
-            // Clean up partial cache on cancellation
-            OpdsExtractionCoordinator.DeleteCacheDirectory(cacheDir);
             throw;
         }
         catch (Exception ex)
         {
-            // On failure, set all pending signals with the exception
+            // On failure (e.g. the archive itself can't be opened), set all pending
+            // signals with the exception. Already-extracted pages stay on disk.
             foreach (var kvp in state.PageSignals)
             {
                 kvp.Value.TrySetException(ex);
             }
-            OpdsExtractionCoordinator.DeleteCacheDirectory(cacheDir);
             throw;
         }
         finally
         {
+            if (lockTaken)
+                chapterLock.Release();
+
             // Only remove our own state if it hasn't been replaced
             if (_coordinator.TryGetExtraction(userKey, out var current) &&
                 ReferenceEquals(current, state))
             {
                 _coordinator.TryRemoveExtraction(userKey, out _);
             }
+
+            cts.Dispose();
         }
     }
 
@@ -780,7 +826,8 @@ public class OpdsImageService
         string seriesStoragePath, string chapterFilename,
         CancellationToken token)
     {
-        string[] allFiles = Directory.GetFiles(cacheDir)
+        // Recursive: archives can contain images inside subdirectories
+        string[] allFiles = Directory.GetFiles(cacheDir, "*", SearchOption.AllDirectories)
             .Where(f => ArchiveHelperService.ArchiveIsImage(f))
             .OrderBy(f => f, new NaturalSortComparer())
             .ToArray();
@@ -788,10 +835,11 @@ public class OpdsImageService
         if (allFiles.Length == 0 || pageIndex >= allFiles.Length)
             return (null, null, null);
 
-        // Group files by their base name (without extension) to handle
-        // multiple format variants of the same page
+        // Group files by their extension-less path relative to the cache dir to
+        // handle multiple format variants of the same page
         var groupedFiles = allFiles
-            .GroupBy(f => System.IO.Path.GetFileNameWithoutExtension(f), StringComparer.OrdinalIgnoreCase)
+            .GroupBy(f => System.IO.Path.ChangeExtension(System.IO.Path.GetRelativePath(cacheDir, f), null),
+                StringComparer.OrdinalIgnoreCase)
             .OrderBy(g => g.Key, new NaturalSortComparer())
             .ToList();
 
@@ -843,7 +891,36 @@ public class OpdsImageService
         return (stream, contentType, md5Hash);
     }
 
-    
+    /// <summary>
+    /// Resolves the on-disk file for an archive entry key, accounting for format
+    /// conversion: <see cref="ImageExtensions.CreateImageFileFormatIfNeeded"/> deletes
+    /// the original after converting, so the cached file may have a different
+    /// extension (e.g. entry "001.webp" exists on disk only as "001.jpg").
+    /// Returns null if neither the original nor a converted variant exists.
+    /// </summary>
+    private static string? ResolvePageFile(string cacheDir, string entryKey)
+    {
+        string exact = System.IO.Path.Combine(cacheDir, entryKey);
+        if (File.Exists(exact))
+            return exact;
+
+        string? dir = System.IO.Path.GetDirectoryName(exact);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+            return null;
+
+        string baseName = System.IO.Path.GetFileNameWithoutExtension(exact);
+        foreach (string candidate in Directory.EnumerateFiles(dir, baseName + ".*"))
+        {
+            if (ArchiveHelperService.ArchiveIsImage(candidate) &&
+                string.Equals(System.IO.Path.GetFileNameWithoutExtension(candidate), baseName, StringComparison.OrdinalIgnoreCase))
+            {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+
 
     // ──────────────────────────────────────────────────────────────────────────
     // Cache management
@@ -886,6 +963,11 @@ public class OpdsImageService
             var oldest = chapterDirs.First();
             try
             {
+                // Remove the completion marker first: if the recursive delete then
+                // fails partway (a page file is open on Windows), the leftover
+                // directory is correctly seen as partial and re-extracted, instead
+                // of being trusted as a complete chapter with missing pages
+                File.Delete(System.IO.Path.Combine(oldest, OpdsExtractionCoordinator.CompleteMarkerFileName));
                 Directory.Delete(oldest, true);
             }
             catch { }


### PR DESCRIPTION
## Summary

Fixes the bug reported on Discord where panels randomly fail to load in OPDS readers (Suwatte etc.), often at the start or end of a chapter, and one bad image takes out many pages. Five related defects in `OpdsImageService` / `OpdsExtractionCoordinator`:

### 1. Format-converted pages 404'd (likely the main cause)
`ImageExtensions.CreateImageFileFormatIfNeeded` **deletes the original file after converting** (e.g. `001.webp` becomes `001.jpg`), but `GetPageImageAsync` checked `File.Exists` on the original entry name — so every converted page returned "Page not found". Cover/credit pages are often a different format than the body, which is why panels at the start/end vanished, and it varied per reader because it depends on the client's advertised image format support. Lookups now resolve converted variants via a `ResolvePageFile` helper.

### 2. One bad entry failed the whole chapter
Any exception on a single archive entry hit the catch-all, which faulted **every** pending page signal and **deleted the entire cache directory**, including pages already extracted. Extraction now isolates per-entry failures: only the broken page's signal faults, the rest keep extracting, and good pages stay on disk.

### 3. The per-chapter lock was never used
`GetChapterLock` existed on the coordinator but had zero callers. Parallel page requests from a reader could each cancel the other's just-started extraction and fire duplicates into the same cache dir — concurrent writes to the same files cause sharing violations on Windows, which then triggered the failure path in #2. Extraction startup is now double-checked under the chapter lock, and the extraction task holds the lock for its duration (a second extractor of the same chapter resumes cheaply by skipping existing files).

### 4. Partial cache dirs were trusted as complete (Windows-specific)
Cancellation deleted the cache dir, but `Directory.Delete` fails half-way on Windows when a page file is open, stranding partial directories. Those were then treated as fully cached (`any file exists` check) and served by index over whatever files remained — consistently missing panels for that title until the cache was cleared. Now:
- a `.complete` marker is written only after a fully successful extraction; directories without it re-extract and **resume** (skip existing files)
- pages are written via temp file + atomic rename, so a cancel/crash never leaves a truncated image behind
- cancellation no longer deletes the cache dir at all
- cache eviction deletes the marker before the directory, so a partially-failed eviction leaves a resumable dir instead of a "complete" one with missing pages

### 5. Preloads stole the active extraction + non-recursive fallback
Background preloads (`PreloadFirstUnreadChapterAsync` etc.) unconditionally canceled the user's in-flight extraction — browsing another series feed mid-chapter could kill the chapter being read. Preloads now skip if an extraction is running. The cache-dir fallback reader also used a non-recursive `Directory.GetFiles`, serving zero pages for archives with internal subfolders; it now scans recursively and groups variants by relative path.

## Testing
- Backend builds clean (0 errors).
- Legacy cache dirs (no marker) are handled: they re-extract once with resume, then get the marker.