### PR TITLE
Fix 'lateinit property title has not been initialized' crash in details fetch

### DIFF
--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Extensions/ConversionsExtensions.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Extensions/ConversionsExtensions.cs
@@ -98,16 +98,23 @@ namespace Mihon.ExtensionsBridge.Core.Extensions
                 HasNextPage = mangaPage.getHasNextPage()
             };
         }
-        public static MangaUpdate ToMangaUpdate(this eu.kanade.tachiyomi.source.model.SMangaUpdate mangaUpdate, eu.kanade.tachiyomi.source.online.HttpSource source)
+        public static MangaUpdate ToMangaUpdate(this eu.kanade.tachiyomi.source.model.SMangaUpdate mangaUpdate, eu.kanade.tachiyomi.source.online.HttpSource source, Manga original = null)
         {
             if (mangaUpdate == null)
                 throw new ArgumentNullException(nameof(mangaUpdate));
+            var smanga = mangaUpdate.getManga();
+            // Extensions may return a partial SManga from fetchMangaDetails without
+            // title/url set (Mihon merges it into the existing manga app-side).
+            // Those are lateinit in Kotlin, so fill them from the request manga
+            // before any getter (getTitle, getMangaUrl) touches them.
+            PrefillMissing(smanga, original);
+            string title = ReadField<string>(smanga, "title", original?.Title ?? string.Empty);
             var update = new MangaUpdate
             {
-                Manga = mangaUpdate.getManga().ToManga<ParsedManga>(),
-                Chapters = mangaUpdate.getChapters().toArray().Cast<SChapter>().ToParsedChapters(mangaUpdate.getManga().getTitle(), mangaUpdate.getManga(), source)
+                Manga = smanga.ToManga<ParsedManga>(original),
+                Chapters = mangaUpdate.getChapters().toArray().Cast<SChapter>().ToParsedChapters(title, smanga, source)
             };
-            update.Manga.RealUrl = source.getMangaUrl(mangaUpdate.getManga());
+            update.Manga.RealUrl = source.getMangaUrl(smanga);
             return update;
         }
         public static string GetString(java.lang.CharSequence seq)
@@ -367,10 +374,13 @@ namespace Mihon.ExtensionsBridge.Core.Extensions
         {
             if (details == null)
                 return;
+            // title/url are lateinit in Kotlin: initialize them even without an
+            // original, so Kotlin-side getters (getMangaUrl, prepareNewChapter)
+            // can't throw UninitializedPropertyAccessException on a partial SManga
+            ReplaceFieldIfNeeded(details, original?.Title, "title", details.setTitle);
+            ReplaceFieldIfNeeded(details, original?.Url, "url", details.setUrl);
             if (original == null)
                 return;
-            ReplaceFieldIfNeeded(details, original.Title, "title", details.setTitle);
-            ReplaceFieldIfNeeded(details, original.Url, "url", details.setUrl);
             ReplaceFieldIfNeeded(details, original.Artist, "artist", details.setArtist);
             ReplaceFieldIfNeeded(details, original.Author, "author", details.setAuthor);
             ReplaceFieldIfNeeded(details, original.Description, "description", details.setDescription);

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
@@ -276,7 +276,7 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
 
                 // Extension overrides getMangaUpdate — use the suspend path
                 var mangaUpdate = await KotlinSuspendBridge.CallSuspend<eu.kanade.tachiyomi.source.model.SMangaUpdate>((cont) => _source.getMangaUpdate(mangaImpl, new java.util.ArrayList(), true, false, cont), token).ConfigureAwait(false);
-                return mangaUpdate.ToMangaUpdate(_httpSource);
+                return mangaUpdate.ToMangaUpdate(_httpSource, manga);
 
             }).ConfigureAwait(false);
         }
@@ -300,7 +300,11 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
                     throw new InvalidOperationException("Source does not support catalogue operations.");
                 SManga mangaImpl = manga.ToSManga();
                 var mangaUpdate = await KotlinSuspendBridge.CallSuspend<eu.kanade.tachiyomi.source.model.SMangaUpdate>((cont) => _source.getMangaUpdate(mangaImpl, new java.util.ArrayList(), false, true, cont), token).ConfigureAwait(false);
-                return mangaUpdate.getChapters().toArray().Cast<SChapter>().ToParsedChapters(mangaUpdate.getManga().getTitle(), mangaUpdate.getManga(), _httpSource);
+                // The returned SManga may be partial (lateinit title/url unset) when
+                // the extension overrides getMangaUpdate — prefill before any getter
+                var resultManga = mangaUpdate.getManga();
+                ConversionsExtensions.PrefillMissing(resultManga, manga);
+                return mangaUpdate.getChapters().toArray().Cast<SChapter>().ToParsedChapters(resultManga.getTitle(), resultManga, _httpSource);
             }).ConfigureAwait(false);
         }
 

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Runtime/SourceInterop.cs
@@ -274,8 +274,10 @@ namespace Mihon.ExtensionsBridge.Core.Runtime
                     throw new InvalidOperationException("Source does not support catalogue operations.");
                 SManga mangaImpl = manga.ToSManga();
 
-                // Extension overrides getMangaUpdate — use the suspend path
-                var mangaUpdate = await KotlinSuspendBridge.CallSuspend<eu.kanade.tachiyomi.source.model.SMangaUpdate>((cont) => _source.getMangaUpdate(mangaImpl, new java.util.ArrayList(), true, false, cont), token).ConfigureAwait(false);
+                // Extension overrides getMangaUpdate — use the suspend path.
+                // fetchDetails AND fetchChapters: callers expect both (a provider
+                // with zero chapters is dropped by search augmentation)
+                var mangaUpdate = await KotlinSuspendBridge.CallSuspend<eu.kanade.tachiyomi.source.model.SMangaUpdate>((cont) => _source.getMangaUpdate(mangaImpl, new java.util.ArrayList(), true, true, cont), token).ConfigureAwait(false);
                 return mangaUpdate.ToMangaUpdate(_httpSource, manga);
 
             }).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Fixes the search-augmentation crash reported by FD1 Gamer:

```
[Rensaio ERR SearchCommandService] Error fetching details for series ID <title>: lateinit property title has not been initialized
kotlin.UninitializedPropertyAccessException: lateinit property title has not been initialized
```

### Root cause

Mihon extensions' `fetchMangaDetails` commonly returns a fresh `SManga.create()` with only the detail fields set — `title` and `url` (both `lateinit` in Kotlin) are left uninitialized, because the real Mihon app merges the result into the existing manga via `copyFrom` and never reads those fields off the network object. The compat layer's default `getMangaUpdate` hands that partial `SManga` straight back, and `ToMangaUpdate` in `ConversionsExtensions` called `getTitle()` directly on it — throwing `UninitializedPropertyAccessException` and failing the entire details fetch for that provider. Whether it triggers depends on how each extension implements `mangaDetailsParse`, which is why it hits some series/providers and not others.

`GetDetailsAsync` was accidentally safe (its `ToManga<ParsedManga>(manga)` call prefills the fields as a side effect before `getMangaUrl` runs), which is why only the `GetDetailsAndChaptersAsync` path (search augmentation) and `GetChaptersAsync` were affected.

### Fix (all .NET-side — no Android.Compat.dll rebuild required)

- `ToMangaUpdate` now takes the original request `Manga`, prefills the returned SManga's missing lateinit fields from it **before** any Kotlin getter runs, and reads the title via the existing safe field-reflection helper with the original title as fallback.
- `PrefillMissing` initializes `title`/`url` even when no original is available (to empty strings), so downstream Kotlin calls (`getMangaUrl`, `prepareNewChapter`) can never hit an uninitialized lateinit either.
- `GetChaptersAsync` had the same direct `getTitle()` call on the returned SManga — same treatment.

Side benefit: chapter-number parsing (`ChapterUtils.ParseChapterNumber`) and `RealUrl` now receive the real title/url of the series instead of crashing or getting empty strings when the extension returns a partial object.

## Testing
- `Mihon.ExtensionsBridge.Core` and `RensaioBackend` build with 0 errors.