### PR TITLE
Detach provider install/uninstall from the HTTP request token

### DIFF
--- a/RensaioBackend/Services/Providers/ProviderManagerService.cs
+++ b/RensaioBackend/Services/Providers/ProviderManagerService.cs
@@ -25,15 +25,26 @@ namespace RensaioBackend.Services.Providers
         private readonly ProviderCacheService _providerCache;
         private readonly ILogger<ProviderManagerService> _logger;
         private readonly AppDbContext _db;
+        private readonly IHostApplicationLifetime _lifetime;
 
-        public ProviderManagerService(MihonBridgeService mihon, AppDbContext db, SettingsService settingsService, ProviderCacheService providerCache, ILogger<ProviderManagerService> logger)
+        public ProviderManagerService(MihonBridgeService mihon, AppDbContext db, SettingsService settingsService, ProviderCacheService providerCache, ILogger<ProviderManagerService> logger, IHostApplicationLifetime lifetime)
         {
             _mihon = mihon;
             _providerCache = providerCache;
             _logger = logger;
             _db = db;
             _settingsService = settingsService;
+            _lifetime = lifetime;
         }
+
+        /// <summary>
+        /// Install/uninstall mutate the database, the extension store and the job schedule across
+        /// many await points; honoring the HTTP request token means a client disconnect (or a
+        /// reverse-proxy timeout, e.g. Cloudflare's ~100s cap) aborts them halfway through and
+        /// leaves the provider cache and schedule stale. Once one of these operations starts it
+        /// must only be cancelled by application shutdown.
+        /// </summary>
+        private CancellationToken DetachedToken => _lifetime.ApplicationStopping;
         /// <summary>
         /// Gets required extensions for a list of provider infos
         /// </summary>
@@ -199,6 +210,7 @@ namespace RensaioBackend.Services.Providers
         /// <returns>True if installation was successful</returns>
         public async Task<bool> InstallProviderAsync(string pkgName, string? repoName, bool force, CancellationToken token = default)
         {
+            token = DetachedToken;
             try
             {
                 _logger.LogInformation("Installing provider: {PkgName}", pkgName);
@@ -264,6 +276,7 @@ namespace RensaioBackend.Services.Providers
         /// <returns>True if installation was successful</returns>
         public async Task<string?> InstallProviderFromFileAsync(byte[] content, bool force, CancellationToken token = default)
         {
+            token = DetachedToken;
             try
             {
                 _logger.LogInformation("Installing provider...");
@@ -335,6 +348,7 @@ namespace RensaioBackend.Services.Providers
         /// <returns>True if uninstallation was successful</returns>
         public async Task<bool> DisableProviderAsync(string pkgName, CancellationToken token = default)
         {
+            token = DetachedToken;
             try
             {
                 _logger.LogInformation("Uninstalling provider: {PkgName}", pkgName);
@@ -386,6 +400,7 @@ namespace RensaioBackend.Services.Providers
 
         public async Task<bool> SetProviderVersionAsync(string pkgName, string version, bool autoUpdate = true, CancellationToken token = default)
         {
+            token = DetachedToken;
             try
             {
                 _logger.LogInformation("Activating provider: {PkgName} version {version}", pkgName, version);


### PR DESCRIPTION
## Problem

Installing an extension does more than download the APK: it re-enables stored providers, reconnects local SeriesProviders (a per-series details/search crawl over the whole library) and refreshes the provider cache. All of that ran on the HTTP request''s cancellation token.

With a large library that crawl takes several minutes, so any client disconnect — in my case Cloudflare Tunnel''s ~100s edge timeout in front of the container — aborts the install halfway through:

- the install is reported as failed (`Error installing provider ...`),
- every in-flight DB open logs `TaskCanceledException` / "An error occurred using the connection to database", which looks alarmingly like DB corruption but isn''t,
- the provider cache refresh and job scheduling never complete, leaving stale state until the next restart.

Live logs from my Docker deploy (both `manhuaus` and `mangafire` installs died this way at almost exactly the 100s mark, right when cloudflared logged `context canceled` for the request):

```
[Rensaiō 05:13:20 ERR Connection          ] An error occurred using the connection to database 'main' on server '/config/rensaio.db'.
[Rensaiō 05:13:20 ERR ProvidManagerService] Error installing provider eu.kanade.tachiyomi.extension.all.mangafire
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at RensaioBackend.Services.Providers.ProviderCacheService.RefreshCacheAsync(...) line 176
   at RensaioBackend.Services.Providers.ProviderManagerService.InstallProviderAsync(...) line 249
```

## Fix

`InstallProviderAsync`, `InstallProviderFromFileAsync`, `DisableProviderAsync` and `SetProviderVersionAsync` now swap the request token for `IHostApplicationLifetime.ApplicationStopping` on entry. Once one of these mutating operations starts, only application shutdown cancels it; a dropped client no longer leaves the DB/extension store/schedule halfway between states. The client may still see its own request time out behind a proxy, but the operation finishes and the UI reflects it on next refresh.

No behavior change for callers that pass background tokens; read-only endpoints keep honoring the request token.