### PR TITLE
Misc fixes: new Mihon extension repo index format + match-sources mobile layout

### DIFF
--- a/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/IndexFormatParsingTests.cs
+++ b/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/IndexFormatParsingTests.cs
@@ -1,0 +1,117 @@
+using Mihon.ExtensionsBridge.Core.Services;
+using Xunit;
+
+namespace Tachiyomi.ExtensionsBridge.Tests
+{
+    public class IndexFormatParsingTests
+    {
+        private const string NewFormatIndex = """
+        {
+          "name": "Keiyoushi",
+          "badgeLabel": "K",
+          "signingKey": "abc123",
+          "contact": { "website": "https://keiyoushi.github.io", "discord": "https://discord.gg/example" },
+          "extensionList": {
+            "extensions": [
+              {
+                "name": "Tachiyomi: MangaDex",
+                "packageName": "eu.kanade.tachiyomi.extension.all.mangadex",
+                "resources": {
+                  "apkUrl": "https://cdn.example.com/apk/tachiyomi-all.mangadex-v1.4.16.apk",
+                  "iconUrl": "https://cdn.example.com/icon/eu.kanade.tachiyomi.extension.all.mangadex.png",
+                  "jarUrl": "https://cdn.example.com/jar/tachiyomi-all.mangadex-v1.4.16.jar"
+                },
+                "extensionLib": "1.4",
+                "versionCode": "42",
+                "versionName": "1.4.16",
+                "contentWarning": "CONTENT_WARNING_NSFW",
+                "sources": [
+                  {
+                    "id": "2499283573021220255",
+                    "name": "MangaDex",
+                    "language": "en",
+                    "homeUrl": "https://mangadex.org"
+                  },
+                  {
+                    "id": "1145824452519314725",
+                    "name": "MangaDex (es)",
+                    "language": "es",
+                    "homeUrl": "https://mangadex.org",
+                    "mirrorUrls": ["https://mirror.mangadex.org"]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """;
+
+        private const string LegacyIndex = """
+        [
+          {
+            "name": "Tachiyomi: Comick",
+            "pkg": "eu.kanade.tachiyomi.extension.all.comick",
+            "apk": "tachiyomi-all.comick-v1.5.30.apk",
+            "lang": "all",
+            "code": 55,
+            "version": "1.5.30",
+            "nsfw": 1,
+            "sources": [
+              {
+                "name": "Comick",
+                "lang": "en",
+                "id": "1234567890",
+                "baseUrl": "https://comick.io",
+                "versionId": 1
+              }
+            ]
+          }
+        ]
+        """;
+
+        [Fact]
+        public void ParseIndexBody_NewFormat_MapsFields()
+        {
+            var extensions = RepositoryDownloader.ParseIndexBody(NewFormatIndex);
+
+            Assert.NotNull(extensions);
+            var ext = Assert.Single(extensions!);
+            Assert.Equal("eu.kanade.tachiyomi.extension.all.mangadex", ext.Package);
+            Assert.Equal("tachiyomi-all.mangadex-v1.4.16.apk", ext.Apk);
+            Assert.Equal("1.4.16", ext.Version);
+            Assert.Equal(42, ext.VersionCode);
+            Assert.Equal(1, ext.Nsfw);
+            // Two sources with different languages -> "all"
+            Assert.Equal("all", ext.Language);
+            Assert.Equal("https://cdn.example.com/icon/eu.kanade.tachiyomi.extension.all.mangadex.png", ext.IconUrl);
+            Assert.Equal(2, ext.Sources.Count);
+            Assert.Equal("2499283573021220255", ext.Sources[0].Id);
+            Assert.Equal("en", ext.Sources[0].Language);
+            Assert.Equal("https://mangadex.org", ext.Sources[0].BaseUrl);
+        }
+
+        [Fact]
+        public void ParseIndexBody_LegacyFormat_ParsesAsToday()
+        {
+            var extensions = RepositoryDownloader.ParseIndexBody(LegacyIndex);
+
+            Assert.NotNull(extensions);
+            var ext = Assert.Single(extensions!);
+            Assert.Equal("eu.kanade.tachiyomi.extension.all.comick", ext.Package);
+            Assert.Equal("tachiyomi-all.comick-v1.5.30.apk", ext.Apk);
+            Assert.Equal("all", ext.Language);
+            Assert.Equal(55, ext.VersionCode);
+            Assert.Equal(1, ext.Nsfw);
+            Assert.Null(ext.IconUrl);
+            var source = Assert.Single(ext.Sources);
+            Assert.Equal("https://comick.io", source.BaseUrl);
+        }
+
+        [Fact]
+        public void ParseIndexBody_ObjectWithoutInlineList_ReturnsNull()
+        {
+            var extensions = RepositoryDownloader.ParseIndexBody("""{ "name": "Repo", "extensionListUrl": "https://example.com/list.json" }""");
+            Assert.Null(extensions);
+        }
+    }
+}

--- a/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/Mihon.ExtensionsBridge.Tests.csproj
+++ b/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/Mihon.ExtensionsBridge.Tests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mihon.ExtensionsBridge.Core\Mihon.ExtensionsBridge.Core.csproj" />

--- a/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/RepositoryAddAllExtensionsTests.cs
+++ b/Mihon.ExtensionsBridge.Net/Internal.Tests/Tachiyomi.ExtensionsBridge.Tests/RepositoryAddAllExtensionsTests.cs
@@ -137,7 +137,7 @@ namespace Tachiyomi.ExtensionsBridge.Tests
             var repo = new TachiyomiRepository("https://raw.githubusercontent.com/keiyoushi/extensions/repo");
 
             var added = await repoMgr.AddOnlineRepositoryAsync(repo);
-            var repos = await repoMgr.ListOnlineRepositoryAsync();
+            var repos = repoMgr.ListOnlineRepositories();
             repo = repos.Find(r => r.Url == repo.Url) ?? repo;
 
             var extMgr = bridge.LocalExtensionManager;

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Extensions/MiscExtensions.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Extensions/MiscExtensions.cs
@@ -80,6 +80,8 @@ public static class MiscExtensions
     }
     public static string GetIconUrl(this TachiyomiExtension ext, TachiyomiRepository repository)
     {
+        if (!string.IsNullOrWhiteSpace(ext.IconUrl))
+            return ext.IconUrl;
         string iconName = ext.Package+"."+"png";
         return $"{RepoFromUrl(repository.Url)}/icon/{iconName}";
     }

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/Dex2JarConverter.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/Dex2JarConverter.cs
@@ -56,8 +56,15 @@ namespace Mihon.ExtensionsBridge.Core.Services
         /// their <c>&lt;init&gt;</c> calls, so the oracle now orders types by their constructor call (matching
         /// dex2jar's NEW emission sites) instead of raw allocation order, fixing leftover mispairing
         /// (ArrayTypeMismatch in generated getFilterList, wrong-subclass filter construction).
+        /// Bumped to 1.3.0 for three related fixes surfaced by BatCave/Bookwalker coroutine state machines:
+        /// the ancestor-<c>&lt;init&gt;</c> retarget (dex2jar keeps the correct <c>NEW T</c> but translates the
+        /// DEX's stripped-ctor <c>invoke-direct &lt;ancestor&gt;.&lt;init&gt;</c> verbatim — "Call to wrong
+        /// initialization method"), the interface bit on static calls to library interfaces
+        /// (<c>Job.cancel$default</c> — "interface method must be invoked using invokeinterface", with such
+        /// classes kept at v52), and max_stack padding so understated dex2jar values no longer abort the
+        /// corrector's dataflow analysis.
         /// </remarks>
-        public const string Version = "1.2.0";
+        public const string Version = "1.3.0";
 
         /// <summary>
         /// Classpath prefix used to redirect certain Android framework classes to compatibility replacements.
@@ -229,7 +236,8 @@ namespace Mihon.ExtensionsBridge.Core.Services
                 // DEX type names are normalised through the same replacement map Transform applied, so a
                 // replaced class reference (e.g. SimpleDateFormat) never miscounts as a mistranslation.
                 var corrector = new DexNewInstanceCorrector(oracle, _logger,
-                    type => _classesToReplace.Contains(type) ? REPLACEMENT_PATH + "/" + type : type);
+                    type => _classesToReplace.Contains(type) ? REPLACEMENT_PATH + "/" + type : type,
+                    IsLibraryInterface);
                 corrector.CorrectAll(entries.Select(e => e.node).ToList());
 
                 // Write each corrected class back (frame hygiene + version lowering applied per class).
@@ -244,6 +252,26 @@ namespace Mihon.ExtensionsBridge.Core.Services
                 try { fs?.close(); } catch { /* ignore */ }
             }
 
+        }
+
+        /// <summary>
+        /// True when the given internal type name resolves to an interface on the compat classloader the
+        /// converted extension will run under. Used to repair dex2jar's interface-blindness on static
+        /// calls to library types (see <see cref="DexNewInstanceCorrector"/>); resolution is
+        /// initialization-free and any failure (type not present) counts as "not an interface".
+        /// </summary>
+        private static bool IsLibraryInterface(string internalName)
+        {
+            try
+            {
+                var cls = java.lang.Class.forName(internalName.Replace('/', '.'), false,
+                    Mihon.ExtensionsBridge.Core.Extensions.MiscExtensions.ClassLoader);
+                return cls.isInterface();
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static bool ShouldRemoveNamespace(string className)

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/DexNewInstanceCorrector.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/DexNewInstanceCorrector.cs
@@ -246,6 +246,8 @@ namespace Mihon.ExtensionsBridge.Core.Services
         private readonly DexNewInstanceOracle _oracle;
         private readonly ILogger _logger;
         private readonly System.Func<string, string>? _normalizeDexType;
+        private readonly System.Func<string, bool>? _isExternalInterface;
+        private readonly Dictionary<string, bool> _externalInterfaceCache = new(System.StringComparer.Ordinal);
 
         /// <summary>Java class-file major version 49 (Java 5) — forces HotSpot's type-inference verifier.</summary>
         private const int TargetMajorVersion = 49;
@@ -255,11 +257,18 @@ namespace Mihon.ExtensionsBridge.Core.Services
         /// class-replacement mapping applied during conversion, e.g. SimpleDateFormat → the
         /// androidcompat replacement). Null means identity.
         /// </param>
-        public DexNewInstanceCorrector(DexNewInstanceOracle oracle, ILogger logger, System.Func<string, string>? normalizeDexType = null)
+        /// <param name="isExternalInterface">
+        /// Resolves whether a library type (not present in the JAR) is an interface, e.g. via the
+        /// compat classloader the extension will run under. Null means unknown (treated as class).
+        /// </param>
+        public DexNewInstanceCorrector(DexNewInstanceOracle oracle, ILogger logger,
+            System.Func<string, string>? normalizeDexType = null,
+            System.Func<string, bool>? isExternalInterface = null)
         {
             _oracle = oracle;
             _logger = logger;
             _normalizeDexType = normalizeDexType;
+            _isExternalInterface = isExternalInterface;
         }
 
         /// <summary>
@@ -275,7 +284,7 @@ namespace Mihon.ExtensionsBridge.Core.Services
 
             // (class, ctor descriptor, super <init> to call — null means the class's own superName)
             var ctorNeeded = new HashSet<(string cls, string desc, string? superToCall)>();
-            int retyped = 0, skippedMethods = 0, splitLocals = 0;
+            int retyped = 0, skippedMethods = 0, splitLocals = 0, itfFixed = 0;
 
             foreach (var cn in nodes)
             {
@@ -284,6 +293,13 @@ namespace Mihon.ExtensionsBridge.Core.Services
                     var mn = (MethodNode)cn.methods.get(i);
                     if (mn.instructions.size() == 0)
                         continue;
+
+                    // dex2jar frequently declares max_stack a few slots too small, which makes ASM's
+                    // Analyzer abort with "Insufficient maximum stack size" and silently skips the whole
+                    // method (Bookwalker's wrong-<init> site hid behind this). WriteClass recomputes the
+                    // real value via COMPUTE_MAXS, so padding the declared one here is free.
+                    mn.maxStack = System.Math.Min(mn.maxStack + 32, 65535);
+
                     try
                     {
                         var result = FixMethod(cn, mn, byName, ctorNeeded);
@@ -308,15 +324,60 @@ namespace Mihon.ExtensionsBridge.Core.Services
                     {
                         _logger.LogTrace(ex, "DexNewInstanceCorrector: local-web split skipped {Class}.{Method}{Desc}", cn.name, mn.name, mn.desc);
                     }
+
+                    itfFixed += FixInterfaceStaticCalls(cn, mn, byName);
                 }
             }
 
             int synth = SynthesizeConstructors(byName, ctorNeeded);
 
-            if (retyped > 0 || synth > 0 || splitLocals > 0)
+            if (retyped > 0 || synth > 0 || splitLocals > 0 || itfFixed > 0)
                 _logger.LogDebug(
-                    "DexNewInstanceCorrector: retypedNew={Retyped} synthCtors={Synth} splitLocals={SplitLocals} skippedMethods={Skipped}",
-                    retyped, synth, splitLocals, skippedMethods);
+                    "DexNewInstanceCorrector: retypedNew={Retyped} synthCtors={Synth} splitLocals={SplitLocals} itfStaticFixed={ItfFixed} skippedMethods={Skipped}",
+                    retyped, synth, splitLocals, itfFixed, skippedMethods);
+        }
+
+        /// <summary>
+        /// Repairs dex2jar's interface-blindness on static calls to library types: DEX
+        /// <c>invoke-static</c> carries no interface bit and the owner (e.g.
+        /// <c>kotlinx/coroutines/Job.cancel$default</c>, a static interface method) is not in the DEX,
+        /// so dex2jar emits a plain <c>Methodref</c> (<c>itf=false</c>). Resolving an interface method
+        /// through a <c>Methodref</c> raises <c>IncompatibleClassChangeError</c> at runtime. In-JAR
+        /// owners are classified by their access flags, library owners through
+        /// <see cref="_isExternalInterface"/> (cached).
+        /// </summary>
+        /// <returns>The number of call sites whose interface flag was corrected.</returns>
+        private int FixInterfaceStaticCalls(ClassNode cn, MethodNode mn, Dictionary<string, ClassNode> byName)
+        {
+            int n = 0;
+            for (AbstractInsnNode p = mn.instructions.getFirst(); p != null; p = p.getNext())
+            {
+                if (p.getOpcode() != Opcodes.INVOKESTATIC)
+                    continue;
+                var min = (MethodInsnNode)p;
+                if (min.itf || min.owner == null || min.owner.Length == 0 || min.owner[0] == '[')
+                    continue;
+
+                bool isInterface;
+                if (byName.TryGetValue(min.owner, out var target))
+                {
+                    isInterface = (target.access & Opcodes.ACC_INTERFACE) != 0;
+                }
+                else if (!_externalInterfaceCache.TryGetValue(min.owner, out isInterface))
+                {
+                    isInterface = _isExternalInterface?.Invoke(min.owner) ?? false;
+                    _externalInterfaceCache[min.owner] = isInterface;
+                }
+
+                if (!isInterface)
+                    continue;
+                min.itf = true;
+                n++;
+                _logger.LogTrace(
+                    "DexNewInstanceCorrector: marked static interface call {Owner}.{Name}{CallDesc} in {Class}.{Method}{Desc}",
+                    min.owner, min.name, min.desc, cn.name, mn.name, mn.desc);
+            }
+            return n;
         }
 
         /// <summary>
@@ -678,7 +739,14 @@ namespace Mihon.ExtensionsBridge.Core.Services
             if (!HasInvokeDynamic(cn))
             {
                 StripFrames(cn);
-                cn.version = TargetMajorVersion;
+                // invokestatic with an InterfaceMethodref (static interface methods, e.g. kotlinx
+                // Job.cancel$default as repaired by FixInterfaceStaticCalls) is only legal in class-file
+                // v52+, and IKVM enforces that gate ("Illegal constant pool index" at v49). IKVM's own
+                // inference verifier ignores StackMapTable, so such classes keep v52 with frames
+                // stripped; everything else keeps the validated v49 lowering.
+                cn.version = HasStaticInterfaceCall(cn)
+                    ? System.Math.Max(cn.version & 0xFFFF, Opcodes.V1_8)
+                    : TargetMajorVersion;
             }
 
             // COMPUTE_MAXS: dex2jar's declared max_stack is frequently too small for HotSpot's v49
@@ -703,34 +771,8 @@ namespace Mihon.ExtensionsBridge.Core.Services
             if (jvmNews.Count == 0)
                 return (0, 0);
 
-            var dex = _oracle.Get(cn.name, mn.name, mn.desc);
-            if (dex == null || dex.Count != jvmNews.Count)
-            {
-                // Diagnostic: this guard leaves an Object-typed NEW unrepaired. If the method
-                // that builds chapters (references 'r' / returns SChapter) lands here, that is a
-                // strong signal the R8 mistranslation for this method is not oracle-recoverable.
-                _logger.LogTrace(
-                    "DexNewInstanceCorrector: oracle mismatch, skipping {Class}.{Method}{Desc} (jvmNews={JvmNews}, dexNews={DexNews})",
-                    cn.name, mn.name, mn.desc, jvmNews.Count, dex == null ? -1 : dex.Count);
-                return (0, jvmNews.Any(t => t.desc == "java/lang/Object") ? 1 : 0);
-            }
-
-            // Normalise DEX types through the same class-replacement map applied during conversion
-            // (e.g. java/text/SimpleDateFormat → xyz/nulldev/.../SimpleDateFormat), so a replaced
-            // reference never counts as a mistranslation nor shadows one.
-            var normDex = new List<string>(dex.Count);
-            foreach (var d in dex)
-                normDex.Add(_normalizeDexType?.Invoke(d) ?? d);
-
-            // dex2jar's stripped-constructor mistranslation emits `NEW <super>` + `invokespecial
-            // <super>.<init>(...)` where the DEX allocated a subclass whose R8-stripped constructor is
-            // gone. NEW placement is not order-stable: dex2jar sinks some NEWs to their <init> site and
-            // leaves others at the (R8-hoisted) DEX allocation position, so any purely positional
-            // pairing of the two lists mispairs. Instead: anchor exact type matches as multisets, then
-            // let each mistranslated site (in <init> order) claim the earliest unclaimed DEX type that
-            // is actually compatible with the site's emitted super and constructor shape.
-
-            // Pair every NEW with its <init> invokespecial through origin tracking.
+            // Pair every NEW with its <init> invokespecial through origin tracking. Runs before the
+            // oracle gate because the ancestor-<init> retarget below is oracle-independent.
             Frame[] frames;
             try
             {
@@ -748,6 +790,7 @@ namespace Mihon.ExtensionsBridge.Core.Services
             // NEW -> (init instruction, init index). First <init> reached wins; conflicting owners bail the site.
             var initOf = new Dictionary<TypeInsnNode, (MethodInsnNode min, int index)>(ReferenceEqualityComparer.Instance);
             var insns = mn.instructions.toArray();
+            int retargeted = 0;
             for (int i = 0; i < insns.Length; i++)
             {
                 if (insns[i].getOpcode() != Opcodes.INVOKESPECIAL)
@@ -764,12 +807,72 @@ namespace Mihon.ExtensionsBridge.Core.Services
                 if (recvIndex < 0)
                     continue;
                 var recv = (SourceValue)fr.getStack(recvIndex);
+                var recvNews = new List<TypeInsnNode>();
+                bool nonNewSource = false;
                 foreach (var src in IterateInsns(recv.insns))
                 {
                     if (src is TypeInsnNode tin && !initOf.ContainsKey(tin))
                         initOf[tin] = (min, i);
+                    if (src is TypeInsnNode nt && nt.getOpcode() == Opcodes.NEW)
+                        recvNews.Add(nt);
+                    else
+                        nonNewSource = true;
                 }
+
+                // Third stripped-ctor shape: the NEW keeps the correct DEX type but the DEX's literal
+                // `invoke-direct <ancestor>.<init>` is translated verbatim, yielding `NEW T` +
+                // `invokespecial U.<init>` with U != T ("Call to wrong initialization method", e.g.
+                // `new b1` initialised via Exception.<init> in a coroutine invokeSuspend). The oracle
+                // cannot flag it — every NEW type matches the DEX — but the bytecode alone proves it:
+                // an object created by `NEW T` may only be initialised by `T.<init>`. Retarget the call
+                // to T and synthesise the pass-through constructor chain T→…→U.
+                if (nonNewSource || recvNews.Count == 0)
+                    continue;
+                string newType = recvNews[0].desc;
+                if (min.owner == newType || !recvNews.TrueForAll(t => t.desc == newType))
+                    continue;
+                if (!IsAncestor(byName, newType, min.owner))
+                    continue;
+                var chain = PlanConstructorChain(byName, newType, min.desc, min.owner);
+                if (chain == null)
+                {
+                    _logger.LogTrace(
+                        "DexNewInstanceCorrector: cannot synthesise ctor chain {Type}->{Owner}{CtorDesc} in {Class}.{Method}{Desc}",
+                        newType, min.owner, min.desc, cn.name, mn.name, mn.desc);
+                    continue;
+                }
+                min.owner = newType;
+                foreach (var link in chain)
+                    ctorNeeded.Add(link);
+                retargeted++;
             }
+
+            var dex = _oracle.Get(cn.name, mn.name, mn.desc);
+            if (dex == null || dex.Count != jvmNews.Count)
+            {
+                // Diagnostic: this guard leaves an Object-typed NEW unrepaired. If the method
+                // that builds chapters (references 'r' / returns SChapter) lands here, that is a
+                // strong signal the R8 mistranslation for this method is not oracle-recoverable.
+                _logger.LogTrace(
+                    "DexNewInstanceCorrector: oracle mismatch, skipping {Class}.{Method}{Desc} (jvmNews={JvmNews}, dexNews={DexNews})",
+                    cn.name, mn.name, mn.desc, jvmNews.Count, dex == null ? -1 : dex.Count);
+                return (retargeted, jvmNews.Any(t => t.desc == "java/lang/Object") ? 1 : 0);
+            }
+
+            // Normalise DEX types through the same class-replacement map applied during conversion
+            // (e.g. java/text/SimpleDateFormat → xyz/nulldev/.../SimpleDateFormat), so a replaced
+            // reference never counts as a mistranslation nor shadows one.
+            var normDex = new List<string>(dex.Count);
+            foreach (var d in dex)
+                normDex.Add(_normalizeDexType?.Invoke(d) ?? d);
+
+            // dex2jar's stripped-constructor mistranslation emits `NEW <super>` + `invokespecial
+            // <super>.<init>(...)` where the DEX allocated a subclass whose R8-stripped constructor is
+            // gone. NEW placement is not order-stable: dex2jar sinks some NEWs to their <init> site and
+            // leaves others at the (R8-hoisted) DEX allocation position, so any purely positional
+            // pairing of the two lists mispairs. Instead: anchor exact type matches as multisets, then
+            // let each mistranslated site (in <init> order) claim the earliest unclaimed DEX type that
+            // is actually compatible with the site's emitted super and constructor shape.
 
             // Multiset anchoring on exact types: the k-th JVM NEW of type X consumes the k-th DEX
             // occurrence of X (up to the smaller count). Whatever remains on each side is the
@@ -807,7 +910,7 @@ namespace Mihon.ExtensionsBridge.Core.Services
             }
 
             if (jvmLeftovers.Count == 0)
-                return (0, 0);
+                return (retargeted, 0);
 
             // Sites are processed in construction order (<init> position); a site without a traceable
             // <init> cannot be validated, so it stays untouched.
@@ -868,7 +971,7 @@ namespace Mihon.ExtensionsBridge.Core.Services
                 }
             }
 
-            return (n, 0);
+            return (n + retargeted, 0);
         }
 
         /// <summary>
@@ -977,6 +1080,18 @@ namespace Mihon.ExtensionsBridge.Core.Services
                     p = next;
                 }
             }
+        }
+
+        private static bool HasStaticInterfaceCall(ClassNode cn)
+        {
+            for (int i = 0; i < cn.methods.size(); i++)
+            {
+                var mn = (MethodNode)cn.methods.get(i);
+                for (AbstractInsnNode p = mn.instructions.getFirst(); p != null; p = p.getNext())
+                    if (p.getOpcode() == Opcodes.INVOKESTATIC && ((MethodInsnNode)p).itf)
+                        return true;
+            }
+            return false;
         }
 
         private static bool HasInvokeDynamic(ClassNode cn)

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/RepositoryDownloader.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Core/Services/RepositoryDownloader.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 using Mihon.ExtensionsBridge.Core.Models;
 using Mihon.ExtensionsBridge.Core.Abstractions;
 
@@ -60,7 +61,10 @@ namespace Mihon.ExtensionsBridge.Core.Services
         }
 
 
-        private static string[] index = ["index.min.json", "index.json"];
+        // index.json first: newer repos (keiyoushi) repurposed index.json as the new protojson
+        // object format while leaving index.min.json as a legacy-format stub, so the legacy
+        // file must only be used as a fallback.
+        private static string[] index = ["index.json", "index.min.json"];
 
         private static string[] repos = ["repo.json"];
 
@@ -127,40 +131,41 @@ namespace Mihon.ExtensionsBridge.Core.Services
                     }
                 }
 
-                // Try index candidates first
+                // Try index candidates: first file whose body parses as a known format wins.
+                List<TachiyomiExtension>? extensions = null;
                 foreach (var fileName in index)
                 {
                     var candidateUrl = repository.Url.CombineUrl(fileName);
                     using var request = new HttpRequestMessage(HttpMethod.Get, candidateUrl);
-                    var tempResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    using var tempResponse = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
                     if (tempResponse.StatusCode == System.Net.HttpStatusCode.NotFound)
                     {
-                        tempResponse.Dispose();
                         _logger.LogDebug("Index not found at {CandidateUrl}. Trying next candidate...", candidateUrl);
                         continue;
                     }
 
                     tempResponse.EnsureSuccessStatusCode();
-                    response = tempResponse;
+                    var body = await tempResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    var parsed = ParseIndexBody(body, _logger);
+                    if (parsed == null)
+                    {
+                        _logger.LogDebug("Unrecognized index format at {CandidateUrl}. Trying next candidate...", candidateUrl);
+                        continue;
+                    }
+
+                    extensions = parsed;
                     usedUrl = candidateUrl;
                     break;
                 }
-                // Fallback to original URL if no index candidate succeeded
-                if (response == null)
+                if (extensions == null)
                 {
                     throw new HttpRequestException("No valid index file found in the repository.");
                 }
 
                 _logger.LogInformation("Resolved repository index at: {ResolvedUrl}", usedUrl);
 
-                await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-                var extensions = await JsonSerializer.DeserializeAsync<List<TachiyomiExtension>>(stream, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                }, cancellationToken).ConfigureAwait(false);
-
-                repository.Extensions = extensions ?? new List<TachiyomiExtension>();
+                repository.Extensions = extensions;
                 repository.LastUpdatedUTC = DateTimeOffset.UtcNow;
 
                 _logger.LogInformation("Downloaded {ExtensionCount} extensions from {ResolvedUrl}. Saving to working folder...", repository.Extensions.Count, usedUrl);
@@ -183,6 +188,112 @@ namespace Mihon.ExtensionsBridge.Core.Services
             {
                 response?.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Parses a repository index body in either the legacy (flat JSON array) format or the
+        /// new Mihon 0.20+ protojson object format, returning the extensions mapped to
+        /// <see cref="TachiyomiExtension"/>. Returns <c>null</c> when the body is not a
+        /// recognized index format (invalid JSON, or an object without an inline extension list),
+        /// so the caller can fall through to the next index file candidate.
+        /// </summary>
+        public static List<TachiyomiExtension>? ParseIndexBody(string body, ILogger? logger = null)
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            JsonValueKind rootKind;
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                rootKind = doc.RootElement.ValueKind;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+
+            if (rootKind == JsonValueKind.Array)
+            {
+                // Legacy format: flat array of extensions.
+                return JsonSerializer.Deserialize<List<TachiyomiExtension>>(body, options) ?? new List<TachiyomiExtension>();
+            }
+
+            if (rootKind == JsonValueKind.Object)
+            {
+                var root = JsonSerializer.Deserialize<MihonIndexV2>(body, options);
+                // Only the inline extension list variant of the oneof is supported;
+                // extensionListUrl (or anything else) falls through to the next candidate.
+                if (root?.ExtensionList?.Extensions == null)
+                    return null;
+                return MapV2Extensions(root.ExtensionList.Extensions, logger);
+            }
+
+            return null;
+        }
+
+        private static List<TachiyomiExtension> MapV2Extensions(List<MihonIndexV2Extension> entries, ILogger? logger)
+        {
+            var result = new List<TachiyomiExtension>();
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrWhiteSpace(entry.PackageName))
+                {
+                    logger?.LogWarning("Skipping index entry '{Name}': missing packageName.", entry.Name);
+                    continue;
+                }
+
+                var apk = ExtractFileNameFromUrl(entry.Resources?.ApkUrl);
+                if (string.IsNullOrWhiteSpace(apk))
+                {
+                    logger?.LogWarning("Skipping index entry '{Package}': missing or invalid apkUrl.", entry.PackageName);
+                    continue;
+                }
+
+                if (!int.TryParse(entry.VersionCode, out var versionCode))
+                {
+                    logger?.LogWarning("Skipping index entry '{Package}': unparseable versionCode '{VersionCode}'.", entry.PackageName, entry.VersionCode);
+                    continue;
+                }
+
+                var sources = entry.Sources ?? new List<MihonIndexV2Source>();
+                var languages = sources.Select(s => s.Language).Distinct().ToList();
+                var language = languages.Count == 1 && !string.IsNullOrWhiteSpace(languages[0]) ? languages[0]! : "all";
+
+                result.Add(new TachiyomiExtension
+                {
+                    Name = entry.Name ?? string.Empty,
+                    Package = entry.PackageName,
+                    Apk = apk,
+                    Language = language,
+                    VersionCode = versionCode,
+                    Version = entry.VersionName ?? string.Empty,
+                    Nsfw = entry.ContentWarning != null && entry.ContentWarning.EndsWith("NSFW", StringComparison.OrdinalIgnoreCase) ? 1 : 0,
+                    IconUrl = entry.Resources?.IconUrl,
+                    Sources = sources.Select(s => new TachiyomiSource
+                    {
+                        Id = s.Id ?? string.Empty,
+                        Name = s.Name ?? string.Empty,
+                        Language = s.Language ?? string.Empty,
+                        BaseUrl = s.HomeUrl ?? string.Empty
+                    }).ToList()
+                });
+            }
+            return result;
+        }
+
+        private static string? ExtractFileNameFromUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+            var path = url;
+            var cut = path.IndexOfAny(new[] { '?', '#' });
+            if (cut >= 0)
+                path = path[..cut];
+            var slash = path.LastIndexOf('/');
+            var segment = slash >= 0 ? path[(slash + 1)..] : path;
+            if (string.IsNullOrWhiteSpace(segment))
+                return null;
+            return Uri.UnescapeDataString(segment);
         }
 
         /// <summary>

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Models/MihonIndexV2.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Models/MihonIndexV2.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+
+namespace Mihon.ExtensionsBridge.Models;
+
+/// <summary>
+/// Root of the new Mihon 0.20+ extension repository index format (protojson <c>index.json</c>).
+/// </summary>
+public record MihonIndexV2
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("badgeLabel")]
+    public string? BadgeLabel { get; set; }
+
+    [JsonPropertyName("signingKey")]
+    public string? SigningKey { get; set; }
+
+    [JsonPropertyName("contact")]
+    public MihonIndexV2Contact? Contact { get; set; }
+
+    /// <summary>
+    /// Inline extension list. This is a protobuf oneof; a repository may instead publish an
+    /// <c>extensionListUrl</c> string, in which case this property is null and the format is
+    /// treated as unsupported (legacy fallback applies).
+    /// </summary>
+    [JsonPropertyName("extensionList")]
+    public MihonIndexV2ExtensionList? ExtensionList { get; set; }
+
+    [JsonPropertyName("extensionListUrl")]
+    public string? ExtensionListUrl { get; set; }
+}
+
+public record MihonIndexV2Contact
+{
+    [JsonPropertyName("website")]
+    public string? Website { get; set; }
+
+    [JsonPropertyName("discord")]
+    public string? Discord { get; set; }
+}
+
+public record MihonIndexV2ExtensionList
+{
+    [JsonPropertyName("extensions")]
+    public List<MihonIndexV2Extension>? Extensions { get; set; }
+}
+
+public record MihonIndexV2Extension
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("packageName")]
+    public string? PackageName { get; set; }
+
+    [JsonPropertyName("resources")]
+    public MihonIndexV2Resources? Resources { get; set; }
+
+    [JsonPropertyName("extensionLib")]
+    public string? ExtensionLib { get; set; }
+
+    /// <summary>Protojson serializes int64 as a JSON string.</summary>
+    [JsonPropertyName("versionCode")]
+    public string? VersionCode { get; set; }
+
+    [JsonPropertyName("versionName")]
+    public string? VersionName { get; set; }
+
+    /// <summary>
+    /// "CONTENT_WARNING_SAFE" | "CONTENT_WARNING_MIXED" | "CONTENT_WARNING_NSFW"
+    /// (may be absent for SAFE; short forms "SAFE"/"MIXED"/"NSFW" are also accepted).
+    /// </summary>
+    [JsonPropertyName("contentWarning")]
+    public string? ContentWarning { get; set; }
+
+    [JsonPropertyName("sources")]
+    public List<MihonIndexV2Source>? Sources { get; set; }
+}
+
+public record MihonIndexV2Resources
+{
+    [JsonPropertyName("apkUrl")]
+    public string? ApkUrl { get; set; }
+
+    [JsonPropertyName("iconUrl")]
+    public string? IconUrl { get; set; }
+
+    [JsonPropertyName("jarUrl")]
+    public string? JarUrl { get; set; }
+}
+
+public record MihonIndexV2Source
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    [JsonPropertyName("homeUrl")]
+    public string? HomeUrl { get; set; }
+
+    [JsonPropertyName("mirrorUrls")]
+    public List<string>? MirrorUrls { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}

--- a/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Models/TachiyomiExtension.cs
+++ b/Mihon.ExtensionsBridge.Net/Mihon.ExtensionsBridge.Models/TachiyomiExtension.cs
@@ -22,4 +22,11 @@ public record TachiyomiExtension
     public int Nsfw { get; set; }
     [JsonPropertyName("sources")]
     public List<TachiyomiSource> Sources { get; set; } = [];
+    /// <summary>
+    /// Absolute icon URL from the new (Mihon 0.20+) repository index format.
+    /// Null for legacy-format repositories; absent in previously persisted repos.
+    /// </summary>
+    [JsonPropertyName("iconUrl")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IconUrl { get; set; }
 }

--- a/RensaioFrontend/src/components/dialogs/provider-match-dialog.tsx
+++ b/RensaioFrontend/src/components/dialogs/provider-match-dialog.tsx
@@ -30,44 +30,54 @@ const ChapterRow = memo(({
   onChapterChange: (index: number, field: keyof ProviderMatchChapter, value: string | number | null) => void;
   renderProviderWithFlag: (matchInfoId: string | null | undefined) => React.ReactNode;
 }) => {
+  const fieldLabel = "mb-1 block text-[11px] font-medium uppercase tracking-wide opacity-70 sm:hidden";
+
   return (
-    <div 
-      className={`flex items-center gap-4 p-2 rounded cursor-pointer transition-colors ${
-        isSelected 
-          ? 'm-1 bg-primary' 
-          : 'm-1 hover:bg-muted/50'
+    <div
+      className={`m-1 flex flex-col gap-2 rounded border p-2 cursor-pointer transition-colors sm:flex-row sm:items-center sm:gap-4 sm:border-transparent ${
+        isSelected
+          ? 'bg-primary text-primary-foreground border-primary'
+          : 'bg-card hover:bg-muted sm:bg-transparent'
       }`}
       onMouseDown={() => onMouseDown(index)}
       onMouseEnter={() => onMouseEnter(index)}
-    >      <div className="w-[35%]">
-        <Input 
-          className="h-7 text-sm" 
+    >
+      <div className="w-full min-w-0 sm:w-[35%]">
+        <span className={fieldLabel}>Filename</span>
+        <Input
+          className="h-8 text-sm sm:h-7"
           value={chapter.filename}
           onChange={(e) => onChapterChange(index, 'filename', e.target.value)}
           onMouseDown={(e) => e.stopPropagation()}
         />
       </div>
-      <div className="w-[35%]">
+      <div className="w-full min-w-0 sm:w-[35%]">
+        <span className={fieldLabel}>Name</span>
         <Input
           value={chapter.chapterName}
           onChange={(e) => onChapterChange(index, 'chapterName', e.target.value)}
-          className="h-7 text-sm"
+          className="h-8 text-sm sm:h-7"
           onMouseDown={(e) => e.stopPropagation()}
         />
-      </div>      <div className="w-[20%]">
-        <div className="h-7 px-3 py-1 text-sm bg-muted rounded border border-input flex items-center pointer-events-none select-none">
-          {renderProviderWithFlag(chapter.matchInfoId)}
-        </div>
       </div>
-      <div className="w-[10%]">
-        <Input
-          type="number"
-          step="0.1"
-          value={chapter.chapterNumber || ""}
-          onChange={(e) => onChapterChange(index, 'chapterNumber', e.target.value ? parseFloat(e.target.value) : null)}
-          className="h-7 text-sm text-right tabular-nums font-mono"
-          onMouseDown={(e) => e.stopPropagation()}
-        />
+      <div className="flex w-full items-end gap-2 sm:contents">
+        <div className="min-w-0 flex-1 sm:w-[20%] sm:flex-none">
+          <span className={fieldLabel}>Source</span>
+          <div className="h-8 px-3 py-1 text-sm text-foreground bg-muted rounded border border-input flex items-center pointer-events-none select-none sm:h-7">
+            {renderProviderWithFlag(chapter.matchInfoId)}
+          </div>
+        </div>
+        <div className="w-20 shrink-0 sm:w-[10%]">
+          <span className={fieldLabel}>Number</span>
+          <Input
+            type="number"
+            step="0.1"
+            value={chapter.chapterNumber || ""}
+            onChange={(e) => onChapterChange(index, 'chapterNumber', e.target.value ? parseFloat(e.target.value) : null)}
+            className="h-8 text-sm text-right tabular-nums font-mono sm:h-7"
+            onMouseDown={(e) => e.stopPropagation()}
+          />
+        </div>
       </div>
     </div>
   );
@@ -496,8 +506,8 @@ export function ProviderMatchDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[85vw] h-auto flex flex-col">
-        <DialogHeader>
+      <DialogContent className="w-[95vw] max-w-[95vw] sm:max-w-[85vw] h-[92dvh] max-h-[92dvh] sm:h-[88vh] sm:max-h-[88vh] flex flex-col gap-3 sm:gap-4 bg-background overflow-x-hidden overflow-y-hidden">
+        <DialogHeader className="shrink-0 pr-10">
           <DialogTitle>Match Source to Chapters</DialogTitle>
         </DialogHeader>
 
@@ -517,24 +527,24 @@ export function ProviderMatchDialog({
             </div>
           </div>
         ) : (
-          <div className="flex-1 flex flex-col gap-4 min-h-0">
-            {/* Selection controls */}
-           {
-           /* Upper scrollable area with chapter rows */}<div className="flex-1 border rounded-md min-h-0">
-              <div className="p-3 border-b bg-muted/50">
+          <div className="flex-1 flex flex-col gap-3 sm:gap-4 min-h-0">
+            {/* Chapter list container — owns its own scrolling, never overlaps the controls */}
+            <div className="flex-1 flex flex-col min-h-0 overflow-hidden border rounded-md bg-card">
+              <div className="shrink-0 p-3 border-b bg-muted">
                 <div className="flex items-center gap-4 text-sm font-medium">
                   <Checkbox
                     checked={selectedChapterIndexes.size === chapters.length && chapters.length > 0}
                     onCheckedChange={handleSelectAll}
                   />
-                  <div className="w-[35%]">Filename</div>
-                  <div className="w-[35%]">Name</div>
-                  <div className="w-[20%]">Source</div>
-                  <div className="w-[10%]">Number</div>
+                  <span className="sm:hidden">Select all</span>
+                  <div className="hidden sm:block sm:w-[35%]">Filename</div>
+                  <div className="hidden sm:block sm:w-[35%]">Name</div>
+                  <div className="hidden sm:block sm:w-[20%]">Source</div>
+                  <div className="hidden sm:block sm:w-[10%]">Number</div>
                 </div>
               </div>
-              <div 
-                className="h-[70vh] overflow-y-auto" 
+              <div
+                className="flex-1 min-h-0 overflow-y-auto overscroll-contain"
                 onMouseUp={handleMouseUp}
                 onMouseMove={handleMouseMove}
                 ref={setScrollContainer}
@@ -556,16 +566,16 @@ export function ProviderMatchDialog({
               </div>
             </div>
 
-            {/* Bottom control area */}
-            <div className="flex flex-col gap-3 p-3 border rounded-md bg-muted/20">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <Label className="text-sm font-medium">Providers:</Label>
-                  <Select 
-                    value={selectedMatchInfoId === NEW_PROVIDER_SENTINEL ? "__new__" : selectedMatchInfoId} 
+            {/* Bottom control area — separate solid container, sits below the list */}
+            <div className="shrink-0 flex flex-col gap-3 p-3 border rounded-md bg-card">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                <div className="flex items-center gap-2 sm:gap-4">
+                  <Label className="text-sm font-medium shrink-0">Providers:</Label>
+                  <Select
+                    value={selectedMatchInfoId === NEW_PROVIDER_SENTINEL ? "__new__" : selectedMatchInfoId}
                     onValueChange={handleProviderSelect}
                   >
-                    <SelectTrigger className="w-48">
+                    <SelectTrigger className="flex-1 min-w-0 sm:flex-none sm:w-48">
                       <SelectValue placeholder="Select source">
                         {selectedMatchInfoId && renderProviderWithFlag(selectedMatchInfoId)}
                       </SelectValue>
@@ -588,20 +598,21 @@ export function ProviderMatchDialog({
                     onClick={handleMatchSelected}
                     disabled={!selectedMatchInfoId || selectedChapterIndexes.size === 0 || selectedMatchInfoId === "__new__"}
                     size="sm"
+                    className="shrink-0"
                   >
                     Match
                   </Button>
                 </div>
 
-                <div className="flex items-center gap-4">
-                  <Label className="text-sm font-medium">Range Fill:</Label>
+                <div className="flex items-center gap-2 sm:gap-4">
+                  <Label className="text-sm font-medium shrink-0">Range Fill:</Label>
                   <Input
                     type="number"
                     step="0.1"
                     placeholder="Start"
                     value={rangeStart}
                     onChange={(e) => setRangeStart(e.target.value)}
-                    className="w-20 h-8"
+                    className="w-full min-w-0 h-8 sm:w-20"
                   />
                   <Input
                     type="number"
@@ -609,12 +620,13 @@ export function ProviderMatchDialog({
                     placeholder="Step"
                     value={rangeStep}
                     onChange={(e) => setRangeStep(e.target.value)}
-                    className="w-20 h-8"
+                    className="w-full min-w-0 h-8 sm:w-20"
                   />
                   <Button
                     onClick={handleFillRange}
                     disabled={!rangeStart || !rangeStep || selectedChapterIndexes.size === 0}
                     size="sm"
+                    className="shrink-0"
                   >
                     Fill
                   </Button>
@@ -623,14 +635,14 @@ export function ProviderMatchDialog({
 
               {/* New provider creation form - shown when "Create New Provider" is selected */}
               {showNewProviderForm && (
-                <div className="flex items-center gap-4 p-3 bg-background border rounded-md">
+                <div className="flex flex-col gap-3 p-3 bg-background border rounded-md sm:flex-row sm:items-end sm:gap-4">
                   <div className="flex flex-col gap-1">
                     <Label className="text-xs text-muted-foreground">Name</Label>
                     <Input
                       placeholder="Provider name"
                       value={newProviderName}
                       onChange={(e) => setNewProviderName(e.target.value)}
-                      className="h-8 w-44"
+                      className="h-8 w-full sm:w-44"
                     />
                   </div>
                   <div className="flex flex-col gap-1">
@@ -639,7 +651,7 @@ export function ProviderMatchDialog({
                       placeholder="Scanlator (optional)"
                       value={newProviderScanlator}
                       onChange={(e) => setNewProviderScanlator(e.target.value)}
-                      className="h-8 w-36"
+                      className="h-8 w-full sm:w-36"
                     />
                   </div>
                   <div className="flex flex-col gap-1">
@@ -648,10 +660,10 @@ export function ProviderMatchDialog({
                       placeholder="en"
                       value={newProviderLanguage}
                       onChange={(e) => setNewProviderLanguage(e.target.value)}
-                      className="h-8 w-20"
+                      className="h-8 w-full sm:w-20"
                     />
                   </div>
-                  <div className="flex items-end gap-2 mt-auto">
+                  <div className="flex items-end gap-2 sm:mt-auto">
                     <Button
                       onClick={handleNewProviderConfirm}
                       disabled={!newProviderName.trim()}
@@ -673,8 +685,8 @@ export function ProviderMatchDialog({
             </div>
           </div>
         )}
-        <DialogFooter>
-          <div className="flex items-center text-sm text-muted-foreground mr-auto">
+        <DialogFooter className="shrink-0 gap-2 sm:gap-0">
+          <div className="flex items-center justify-center text-sm text-muted-foreground sm:mr-auto">
             ({selectedChapterIndexes.size} of {chapters.length} selected)
           </div>
           <Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/RensaioFrontend/src/styles/globals.css
+++ b/RensaioFrontend/src/styles/globals.css
@@ -561,11 +561,9 @@ body[data-scroll-locked] .page-shell-main {
   overflow: hidden !important;
 }
 
-/* The glass command card */
+/* The command card — solid, no see-through backdrop */
 .cmd-card {
-  background: hsla(240 10% 8% / 0.9);
-  backdrop-filter: blur(28px) saturate(160%);
-  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  background: hsl(240 10% 8%);
   border: 1px solid hsla(var(--as-border-strong));
   border-radius: 14px;
   box-shadow:
@@ -1640,9 +1638,7 @@ body[data-scroll-locked] .page-shell-main {
 }
 
 .as-sources-panel {
-  background: hsla(var(--as-bg-1) / 0.92) !important;
-  backdrop-filter: blur(20px) saturate(150%);
-  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  background: hsl(var(--as-bg-1)) !important;
   border: 1px solid hsla(var(--as-border-strong)) !important;
   border-radius: 12px !important;
   padding: 6px !important;


### PR DESCRIPTION
This bundles three small fixes.

## New Mihon 0.20 / keiyoushi extension repo index format

On 2026-07-29 keiyoushi replaced its legacy `index.min.json` with a 2-entry "Outdated App" stub and moved the real catalog to the Mihon 0.20 format (`index.pb` plus a protojson `index.json`), which broke extension listing/updating against that repo.

Changes in `RepositoryDownloader`:
- Fetches `index.json` first and detects the root shape: an object with `extensionList` is treated as the new format, a JSON array as the legacy format.
- New-format entries are mapped into the existing `TachiyomiExtension` model; the apk filename is extracted from the absolute `apkUrl`, so the existing `{repo}/apk/{file}` download path is unchanged.
- Full legacy-format fallback is kept, so old-style repos keep working as before.
- Carries the new per-extension `iconUrl` (keiyoushi deleted the `/icon/` directory), with fallback to the legacy icon path for repos that do not provide one.
- No protobuf dependency is introduced; only the JSON index is used.
- Unit tests added covering both the new and legacy index formats.

## Match-sources dialog mobile layout

Fixes the match-sources dialog layout on mobile widths and removes the glass surfaces from the dialog.

## dex2jar mistranslation fixes

Fixes wrong-initialization-method and interface-static mistranslations in the dex2jar correction pass. This is complementary to the generalized stripped-constructor correction already merged in #70 and covers cases not handled there.