### PR TITLE
fix: preserve JSON source requests through FlareSolverr

### DIFF
--- a/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/build.gradle.kts
+++ b/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.serialization.json.okio)
 
     testImplementation(libs.bundles.sharedTest)
+    testImplementation(kotlin("test"))
 
     // Android stub library
     implementation(libs.android.stubs)

--- a/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -58,10 +58,11 @@ class CloudflareInterceptor(
             originalResponse.close()
             // network.cookieStore.remove(originalRequest.url.toUri())
 
-            val flareResponseFallback = Settings.flareSolverrAsResponseFallback
+            val target = with(CFClearance) { originalRequest.toFlareSolverTarget() }
+            val flareResponseFallback = Settings.flareSolverrAsResponseFallback && target.canUseResponseFallback
             val flareResponse =
                 runBlocking {
-                    CFClearance.resolveWithFlareSolver(originalRequest, !flareResponseFallback)
+                    CFClearance.resolveWithFlareSolver(originalRequest, target, !flareResponseFallback)
                 }
 
             if (flareResponse.message.contains("not detected", ignoreCase = true)) {
@@ -125,6 +126,41 @@ object CFClearance {
     private val jsonMediaType = "application/json".toMediaType()
     private val mutex = Mutex()
 
+    internal data class FlareSolverTarget(
+        val cmd: String,
+        val url: String,
+        val postData: String? = null,
+        val canUseResponseFallback: Boolean = true,
+    )
+
+    internal fun Request.toFlareSolverTarget(): FlareSolverTarget {
+        if (method == "GET") {
+            return FlareSolverTarget("request.get", url.toString())
+        }
+
+        val requestBody = body
+        if (method == "POST" && requestBody is FormBody) {
+            val postData =
+                Buffer()
+                    .also { requestBody.writeTo(it) }
+                    .readUtf8()
+            return FlareSolverTarget("request.post", url.toString(), postData)
+        }
+
+        // FlareSolverr's request.post only supports application/x-www-form-urlencoded.
+        // Solve at the origin for JSON and other request types, then retry the untouched
+        // original request with the returned clearance cookies.
+        val origin =
+            url
+                .newBuilder()
+                .encodedPath("/")
+                .encodedQuery(null)
+                .fragment(null)
+                .build()
+                .toString()
+        return FlareSolverTarget("request.get", origin, canUseResponseFallback = false)
+    }
+
     @Serializable
     data class FlareSolverCookie(
         val name: String,
@@ -179,8 +215,9 @@ object CFClearance {
         val version: String,
     )
 
-    suspend fun resolveWithFlareSolver(
+    internal suspend fun resolveWithFlareSolver(
         originalRequest: Request,
+        target: FlareSolverTarget,
         onlyCookies: Boolean,
     ): FlareSolverResponse {
         val timeout = Settings.flareSolverrTimeout.seconds
@@ -194,8 +231,8 @@ object CFClearance {
                                 Json
                                     .encodeToString(
                                         FlareSolverRequest(
-                                            "request.${originalRequest.method.lowercase()}",
-                                            originalRequest.url.toString(),
+                                            target.cmd,
+                                            target.url,
                                             session = Settings.flareSolverrSessionName,
                                             sessionTtlMinutes = Settings.flareSolverrSessionTtl,
                                             cookies =
@@ -207,22 +244,7 @@ object CFClearance {
                                                     },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData =
-                                                if (originalRequest.method == "POST") {
-                                                    when (val body = originalRequest.body) {
-                                                        is FormBody -> {
-                                                            Buffer()
-                                                                .also { body.writeTo(it) }
-                                                                .readUtf8()
-                                                        }
-
-                                                        else -> {
-                                                            ""
-                                                        }
-                                                    }
-                                                } else {
-                                                    null
-                                                },
+                                            postData = target.postData,
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),

--- a/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/test/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptorTest.kt
+++ b/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/test/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptorTest.kt
@@ -1,0 +1,60 @@
+package eu.kanade.tachiyomi.network.interceptor
+
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CloudflareInterceptorTest {
+    @Test
+    fun `form post is forwarded through request post`() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com/search?page=2")
+                .post(FormBody.Builder().add("query", "one piece").build())
+                .build()
+
+        val target = with(CFClearance) { request.toFlareSolverTarget() }
+
+        assertEquals("request.post", target.cmd)
+        assertEquals("https://example.com/search?page=2", target.url)
+        assertEquals("query=one+piece", target.postData)
+        assertEquals(true, target.canUseResponseFallback)
+    }
+
+    @Test
+    fun `json post solves at origin and leaves body for okhttp retry`() {
+        val jsonBody = """{"title":"one piece"}""".toRequestBody("application/json".toMediaType())
+        val request =
+            Request
+                .Builder()
+                .url("https://kagane.to/api/v2/search/series?page=0&size=35")
+                .post(jsonBody)
+                .build()
+
+        val target = with(CFClearance) { request.toFlareSolverTarget() }
+
+        assertEquals("request.get", target.cmd)
+        assertEquals("https://kagane.to/", target.url)
+        assertNull(target.postData)
+        assertEquals(false, target.canUseResponseFallback)
+        assertEquals(jsonBody, request.body)
+        assertEquals("application/json; charset=utf-8", request.body?.contentType().toString())
+    }
+
+    @Test
+    fun `get keeps its original target`() {
+        val request = Request.Builder().url("https://example.com/path?q=value").build()
+
+        val target = with(CFClearance) { request.toFlareSolverTarget() }
+
+        assertEquals("request.get", target.cmd)
+        assertEquals("https://example.com/path?q=value", target.url)
+        assertNull(target.postData)
+        assertEquals(true, target.canUseResponseFallback)
+    }
+}

--- a/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
+++ b/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41ba846e96d4d13eb43bd0f1d27db16fbca1ce855a39c236c6111af816557a0a
-size 207093248
+oid sha256:95dbd5bb4c0d33a65b64a25cf9e969efee4b43d25624139b712eccd1e29471ce
+size 207098368


### PR DESCRIPTION
## Summary

- fixes Kagane 1.6.31 JSON search requests being converted to FlareSolverr request.post with empty postData
- keeps FlareSolverr's supported URL-encoded FormBody POST behavior unchanged
- solves unsupported JSON/other requests with a GET to the site origin, then retries the untouched original OkHttp request with clearance cookies
- disables response fallback for the origin-only solve so homepage HTML cannot replace the requested API response
- regenerates the tracked Android.Compat.dll and adds focused request-conversion tests

## Evidence

Kagane sends application/json to /api/v2/search/series. The Mihon 1.6 bridge conversion only serialized FormBody and emitted an empty string for every other POST body. FlareSolverr's request.post contract supports only application/x-www-form-urlencoded, so forwarding the raw JSON through that command would still use the wrong target content type.

## Validation

- Android compatibility tests: 3 passed
- AndroidCompat fat JAR build: passed
- IKVM build and CIL patch regeneration: passed
- RensaioBackend build: passed
- existing C# bridge test project remains blocked on upstream main by IRepositoryManager.ListOnlineRepositoryAsync being absent; this PR does not touch that interface or test