### PR TITLE
fix: silent empty search when PreferredLanguages is empty

### DIFF
--- a/RensaioBackend/Controllers/SearchController.cs
+++ b/RensaioBackend/Controllers/SearchController.cs
@@ -116,6 +116,14 @@ namespace RensaioBackend.Controllers
                 .Where(l => !string.IsNullOrWhiteSpace(l))
                 .ToList();
 
+            if (languageList.Count == 0)
+            {
+                // An empty PreferredLanguages setting would otherwise make every search return
+                // an empty list while looking like a successful request.
+                _logger.LogWarning("Search requested with no languages and PreferredLanguages is empty; falling back to 'en'. Check Settings > Preferred Languages.");
+                languageList = ["en"];
+            }
+
             try
             {
                 var results = await _searchQueryService.SearchSeriesAsync(keyword, languageList, searchSources, 0.1f, token).ConfigureAwait(false);

--- a/RensaioBackend/Services/Search/SearchQueryService.cs
+++ b/RensaioBackend/Services/Search/SearchQueryService.cs
@@ -95,6 +95,8 @@ namespace RensaioBackend.Services.Search
         {
             if (string.IsNullOrWhiteSpace(keyword) || languages == null || languages.Count == 0)
             {
+                _logger.LogWarning("Search for '{keyword}' skipped: {reason}.", keyword,
+                    string.IsNullOrWhiteSpace(keyword) ? "empty keyword" : "no languages provided");
                 return [];
             }
 


### PR DESCRIPTION
## Problem

A search request with no `languages` query param and an empty `PreferredLanguages` setting ends up with an empty language list. `SearchQueryService`'s guard then returns an empty result set for every source as a successful HTTP 200 — without logging a single line. From the user's perspective every search silently returns nothing, and the container logs show no trace that a search even happened.

Found while debugging a user report (Discord, Jtecx): all searches returning empty on a fresh container while `SearchQueryService` produced zero log output.

## Fix

- **SearchController**: when both the query param and `PreferredLanguages` yield no languages, log a loud warning and fall back to `en` — mirroring the existing `en` fallback in `GetAvailableSearchSourcesAsync` (the reason the sources list still looks populated while searches die).
- **SearchQueryService**: the early-return guard now logs a warning (empty keyword / no languages) so an empty search can never be silent again.

## Validation

- `RensaioBackend` builds clean; no behavior change for any request that has at least one language.